### PR TITLE
Initial support for loading ROM carts at the command line

### DIFF
--- a/src/glue.h
+++ b/src/glue.h
@@ -16,9 +16,11 @@
 
 #define NUM_MAX_RAM_BANKS 256
 #define NUM_ROM_BANKS 32
+#define NUM_CART_BANKS (256 - 32)
 
 #define RAM_SIZE (0xa000 + num_ram_banks * 8192) /* $0000-$9FFF + banks at $A000-$BFFF */
 #define ROM_SIZE (NUM_ROM_BANKS * 16384)   /* banks at $C000-$FFFF */
+#define CART_SIZE (NUM_CART_BANKS * 16384)  /* expansion banks at $C000-$FFFF */
 
 typedef enum {
 	ECHO_MODE_NONE,
@@ -46,6 +48,7 @@ extern uint8_t a, x, y, sp, status;
 extern uint16_t pc;
 extern uint8_t *RAM;
 extern uint8_t ROM[];
+extern uint8_t *CART;
 
 extern uint16_t num_ram_banks;
 

--- a/src/main.c
+++ b/src/main.c
@@ -118,6 +118,7 @@ char *scale_quality = "best";
 bool test_init_complete=false;
 bool headless = false;
 bool testbench = false;
+SDL_RWops *cartridge_file;
 
 #ifdef TRACE
 bool trace_mode = false;
@@ -406,6 +407,8 @@ usage()
 	printf("\tEnable a specific keyboard layout decode table.\n");
 	printf("-sdcard <sdcard.img>\n");
 	printf("\tSpecify SD card image (partition map + FAT32)\n");
+	printf("-cart <cart.bin>\n");
+	printf("\tSpecify cartridge binary, which is loaded into ROM bank 32 and above\n");
 	printf("-serial\n");
 	printf("\tConnect host fs through Serial Bus [experimental]\n");
 	printf("-nohostieee\n");
@@ -527,6 +530,7 @@ main(int argc, char **argv)
 	char *prg_path = NULL;
 	char *bas_path = NULL;
 	char *sdcard_path = NULL;
+	char *cartridge_path = NULL;
 	bool run_geos = false;
 	bool run_test = false;
 	int test_number = 0;
@@ -639,6 +643,15 @@ main(int argc, char **argv)
 				usage();
 			}
 			sdcard_path = argv[0];
+			argc--;
+			argv++;
+		} else if (!strcmp(argv[0], "-cart")) {
+			argc--;
+			argv++;
+			if (!argc || argv[0][0] == '-') {
+				usage();
+			}
+			cartridge_path = argv[0];
 			argc--;
 			argv++;
 		} else if (!strcmp(argv[0], "-warp")) {
@@ -924,6 +937,15 @@ main(int argc, char **argv)
 			exit(1);
 		}
 		sdcard_attach();
+	}
+
+	if (cartridge_path) {
+		cartridge_file = SDL_RWFromFile(cartridge_path, "r+b");
+		if (!cartridge_file) {
+			printf("Cannot open %s!\n", cartridge_path);
+			exit(1);
+		}
+		cartridge_attach();
 	}
 
 	prg_override_start = -1;

--- a/src/main.c
+++ b/src/main.c
@@ -408,7 +408,8 @@ usage()
 	printf("-sdcard <sdcard.img>\n");
 	printf("\tSpecify SD card image (partition map + FAT32)\n");
 	printf("-cart <cart.bin>\n");
-	printf("\tSpecify cartridge binary, which is loaded into ROM bank 32 and above\n");
+	printf("\tSpecify cartridge binary to be loaded ROM bank 32 and above\n");
+	printf("\tThis option enables the full 3.5MB RAM/ROM expansion\n");
 	printf("-serial\n");
 	printf("\tConnect host fs through Serial Bus [experimental]\n");
 	printf("-nohostieee\n");

--- a/src/memory.c
+++ b/src/memory.c
@@ -21,7 +21,7 @@ uint8_t rom_bank;
 
 uint8_t *RAM;
 uint8_t ROM[ROM_SIZE];
-uint8_t *CART;
+uint8_t *CART = NULL;
 
 static uint8_t addr_ym = 0;
 

--- a/src/memory.c
+++ b/src/memory.c
@@ -255,7 +255,7 @@ memory_get_ram_bank()
 void
 memory_set_rom_bank(uint8_t bank)
 {
-	rom_bank = bank & 0xff;;
+	rom_bank = bank;
 }
 
 uint8_t
@@ -377,7 +377,7 @@ emu_read(uint8_t reg, bool debugOn)
 
 void cartridge_attach(void)
 {
-	size_t ret = SIZE_MAX;
+	size_t ret = -1;
 	size_t i = 0;
 
 	if (cartridge_file) {

--- a/src/memory.h
+++ b/src/memory.h
@@ -30,4 +30,8 @@ uint8_t memory_get_rom_bank();
 uint8_t emu_read(uint8_t reg, bool debugOn);
 void emu_write(uint8_t reg, uint8_t value);
 
+void cartridge_attach(void);
+
+extern SDL_RWops *cartridge_file;
+
 #endif


### PR DESCRIPTION
This is a very simple implementation, but it functions as a simple cartridge loader.

The allocation of RAM if the `-cart` command line switch is specified to load a cartridge file, it will allocate all 3.5MB of RAM and load the cartridge data starting at the beginning of this space.

The data loaded from the file specified by the `-cart` command is not write-protected.

A future enhancement should allow enabling this space without also needing to load a cart.