### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
   <img src="./.gh/logo.png" />
 </p>
 
-[![Build Status](https://github.com/commanderx16/x16-emulator/actions/workflows/build.yml/badge.svg)](https://github.com/commanderx16/x16-emulator/actions/workflows/build.yml)
+[![Build Status](https://github.com/x16community/x16-emulator/actions/workflows/build.yml/badge.svg)](https://github.com/x16community/x16-emulator/actions/workflows/build.yml)
 [![Release](https://img.shields.io/github/v/release/commanderx16/x16-emulator)](https://github.com/commanderx16/x16-emulator/releases)
-[![License: BSD-Clause](https://img.shields.io/github/license/commanderx16/x16-emulator)](./LICENSE)
-[![Contributors](https://img.shields.io/github/contributors/commanderx16/x16-emulator.svg)](https://github.com/commanderx16/x16-emulator/graphs/contributors)
+[![License: BSD-Clause](https://img.shields.io/github/license/x16community/x16-emulator)](./LICENSE)
+[![Contributors](https://img.shields.io/github/contributors/x16community/x16-emulator.svg)](https://github.com/x16community/x16-emulator/graphs/contributors)
 
 This is an emulator for the Commander X16 computer system. It only depends on SDL2 and should compile on all modern operating systems.
 


### PR DESCRIPTION
Most shields should now refer to x16community instead of commanderx16. Exception is the "releases" shield, which we'll want to update once we release the next emulator revision.