### PR TITLE
[SDCARD] Prevent seeking beyond the end of the SD card.

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -923,6 +923,7 @@ main(int argc, char **argv)
 			printf("Cannot open %s!\n", sdcard_path);
 			exit(1);
 		}
+		sdcard_size = SDL_RWseek(sdcard_file, 0, SEEK_END);
 		sdcard_attach();
 	}
 

--- a/src/sdcard.c
+++ b/src/sdcard.c
@@ -223,7 +223,13 @@ sdcard_handle(uint8_t inbyte)
 				case CMD24: {
 					// WRITE_BLOCK
 					lba = (rxbuf[1] << 24) | (rxbuf[2] << 16) | (rxbuf[3] << 8) | rxbuf[4];
-					set_response_r1();
+					if (rxbuf_idx >= 4 && (Sint64)lba * 512 >= sdcard_size) {
+						static uint8_t bad_lba[2] = {0x00, 0x08};
+						response = bad_lba;
+						response_length = 2;
+					} else {
+						set_response_r1();
+					}
 					break;
 				}
 

--- a/src/sdcard.c
+++ b/src/sdcard.c
@@ -204,11 +204,11 @@ sdcard_handle(uint8_t inbyte)
 #ifdef VERBOSE
 					printf("*** SD Reading LBA %d\n", lba);
 #endif
-					if (lba * 512 >= sdcard_size) {
+					if ((Sint64)lba * 512 >= sdcard_size) {
 						read_block_response[1] = 0x08; // out of range
 						response_length = 2;
 					} else {
-						SDL_RWseek(sdcard_file, lba * 512, SEEK_SET);
+						SDL_RWseek(sdcard_file, (Sint64)lba * 512, SEEK_SET);
 						int bytes_read = SDL_RWread(sdcard_file, &read_block_response[2], 1, 512);
 						if (bytes_read != 512) {
 							printf("Warning: short read!\n");
@@ -261,10 +261,10 @@ sdcard_handle(uint8_t inbyte)
 #ifdef VERBOSE
 				printf("*** SD Writing LBA %d\n", lba);
 #endif
-				if (lba * 512 >= sdcard_size) {
+				if ((Sint64)lba * 512 >= sdcard_size) {
 					// do nothing?
 				} else {
-					SDL_RWseek(sdcard_file, lba * 512, SEEK_SET);
+					SDL_RWseek(sdcard_file, (Sint64)lba * 512, SEEK_SET);
 					int bytes_written = SDL_RWwrite(sdcard_file, rxbuf + 1, 1, 512);
 					if (bytes_written != 512) {
 						printf("Warning: short write!\n");

--- a/src/sdcard.c
+++ b/src/sdcard.c
@@ -223,7 +223,7 @@ sdcard_handle(uint8_t inbyte)
 				case CMD24: {
 					// WRITE_BLOCK
 					lba = (rxbuf[1] << 24) | (rxbuf[2] << 16) | (rxbuf[3] << 8) | rxbuf[4];
-					if (rxbuf_idx >= 4 && (Sint64)lba * 512 >= sdcard_size) {
+					if (rxbuf_idx > 4 && (Sint64)lba * 512 >= sdcard_size) {
 						static uint8_t bad_lba[2] = {0x00, 0x08};
 						response = bad_lba;
 						response_length = 2;

--- a/src/sdcard.h
+++ b/src/sdcard.h
@@ -9,6 +9,7 @@
 
 extern SDL_RWops *sdcard_file;
 extern bool sdcard_attached;
+extern Sint64 sdcard_size;
 
 void sdcard_attach();
 void sdcard_detach();


### PR DESCRIPTION
These changes bound the writable and readable area of the emulated SD card to the size of the file.

Closes #4 and Closes #5