### PR TITLE
[SDCARD] Zlib support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,7 @@ jobs:
           CROSS_COMPILE_WINDOWS=1 SDL2CONFIG=sdl2-config make V=1 -j2
           mkdir emu_binaries
           cp $(which SDL2.dll) emu_binaries/.
+          cp $(which zlib1.dll) emu_binaries/.
           cp sdcard.img.zip emu_binaries/.
           cp x16emu.exe emu_binaries/.
           file emu_binaries/*
@@ -57,6 +58,7 @@ jobs:
           WIN_SDL2=/mingw32 TARGET_CPU=x86 CROSS_COMPILE_WINDOWS=1 make V=1 -j2
           mkdir emu_binaries
           cp $(which SDL2.dll) emu_binaries/.
+          cp $(which zlib1.dll) emu_binaries/.
           cp sdcard.img.zip emu_binaries/.
           cp x16emu.exe emu_binaries/.
           file emu_binaries/*

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ OUTPUT=x16emu
 
 ifeq ($(MAC_STATIC),1)
 	LIBSDL_FILE?=/opt/homebrew/Cellar/sdl2/2.0.20/lib/libSDL2.a
-	LDFLAGS=$(LIBSDL_FILE) -lm -liconv -Wl,-framework,CoreAudio -Wl,-framework,AudioToolbox -Wl,-framework,ForceFeedback -lobjc -Wl,-framework,CoreVideo -Wl,-framework,Cocoa -Wl,-framework,Carbon -Wl,-framework,IOKit -Wl,-weak_framework,QuartzCore -Wl,-weak_framework,Metal -Wl,-weak_framework,CoreHaptics -Wl,-weak_framework,GameController
+	LDFLAGS=$(LIBSDL_FILE) -lm -liconv -lz -Wl,-framework,CoreAudio -Wl,-framework,AudioToolbox -Wl,-framework,ForceFeedback -lobjc -Wl,-framework,CoreVideo -Wl,-framework,Cocoa -Wl,-framework,Carbon -Wl,-framework,IOKit -Wl,-weak_framework,QuartzCore -Wl,-weak_framework,Metal -Wl,-weak_framework,CoreHaptics -Wl,-weak_framework,GameController
 endif
 
 ifeq ($(CROSS_COMPILE_WINDOWS),1)

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ else
 endif
 
 CFLAGS=-std=c99 -O3 -Wall -Werror -g $(shell $(SDL2CONFIG) --cflags) -Isrc/extern/include -Isrc/extern/src
-LDFLAGS=$(shell $(SDL2CONFIG) --libs) -lm
+LDFLAGS=$(shell $(SDL2CONFIG) --libs) -lm -lz
 
 ODIR = build
 SDIR = src
@@ -57,9 +57,9 @@ ifdef EMSCRIPTEN
 	OUTPUT=x16emu.html
 endif
 
-_OBJS = cpu/fake6502.o memory.o disasm.o video.o i2c.o smc.o rtc.o via.o serial.o ieee.o vera_spi.o audio.o vera_pcm.o vera_psg.o sdcard.o main.o debugger.o javascript_interface.o joystick.o rendertext.o keyboard.o icon.o timing.o wav_recorder.o testbench.o
+_OBJS = cpu/fake6502.o memory.o disasm.o video.o i2c.o smc.o rtc.o via.o serial.o ieee.o vera_spi.o audio.o vera_pcm.o vera_psg.o sdcard.o main.o debugger.o javascript_interface.o joystick.o rendertext.o keyboard.o icon.o timing.o wav_recorder.o testbench.o files.o
 
-_HEADERS = audio.h cpu/65c02.h cpu/fake6502.h cpu/instructions.h cpu/mnemonics.h cpu/modes.h cpu/support.h cpu/tables.h debugger.h disasm.h extern/include/gif.h extern/src/ym2151.h glue.h i2c.h icon.h joystick.h keyboard.h ieee.h memory.h rendertext.h rom_symbols.h rtc.h sdcard.h smc.h timing.h utf8.h utf8_encode.h vera_pcm.h vera_psg.h vera_spi.h version.h via.h serial.o video.h wav_recorder.h testbench.h
+_HEADERS = audio.h cpu/65c02.h cpu/fake6502.h cpu/instructions.h cpu/mnemonics.h cpu/modes.h cpu/support.h cpu/tables.h debugger.h disasm.h extern/include/gif.h extern/src/ym2151.h glue.h i2c.h icon.h joystick.h keyboard.h ieee.h memory.h rendertext.h rom_symbols.h rtc.h sdcard.h smc.h timing.h utf8.h utf8_encode.h vera_pcm.h vera_psg.h vera_spi.h version.h via.h serial.o video.h wav_recorder.h testbench.h files.h
 
 _OBJS += extern/src/ym2151.o
 _HEADERS += extern/src/ym2151.h

--- a/Makefile
+++ b/Makefile
@@ -52,8 +52,8 @@ endif
 ifdef EMSCRIPTEN
 	LDFLAGS+=--shell-file webassembly/x16emu-template.html --preload-file rom.bin -s TOTAL_MEMORY=32MB -s ASSERTIONS=1 -s DISABLE_DEPRECATED_FIND_EVENT_TARGET_BEHAVIOR=1
 	# To the Javascript runtime exported functions
-	LDFLAGS+=-s EXPORTED_FUNCTIONS='["_j2c_reset", "_j2c_paste", "_j2c_start_audio", _main]' -s EXTRA_EXPORTED_RUNTIME_METHODS='["ccall", "cwrap"]'
-
+	LDFLAGS+=-s EXPORTED_FUNCTIONS='["_j2c_reset", "_j2c_paste", "_j2c_start_audio", _main]' -s EXTRA_EXPORTED_RUNTIME_METHODS='["ccall", "cwrap"]' -s USE_ZLIB=1
+	CFLAGS+=-s USE_ZLIB=1
 	OUTPUT=x16emu.html
 endif
 

--- a/src/files.c
+++ b/src/files.c
@@ -1,5 +1,11 @@
+#ifndef __APPLE__
+#define _XOPEN_SOURCE   600
+#define _POSIX_C_SOURCE 1
+#endif
+
 #include "files.h"
 
+#include <limits.h>
 #include <string.h>
 #include <stdlib.h>
 #include <SDL.h>

--- a/src/files.c
+++ b/src/files.c
@@ -1,6 +1,36 @@
 #include "files.h"
 
 #include <string.h>
+#include <stdlib.h>
+#include <SDL.h>
+#include <zlib.h>
+
+struct x16file
+{
+	char path[PATH_MAX];
+
+	SDL_RWops *file;
+	int64_t size;
+	int64_t pos;
+
+	struct x16file *next;
+};
+
+struct x16file *open_files = NULL;
+
+static bool 
+get_tmp_name(char *path_buffer, const char *original_path, char const *extension)
+{
+	if(strlen(original_path) > PATH_MAX - strlen(extension)) {
+		printf("Path too long, cannot create temp file: %s\n", original_path);
+		return false;
+	}
+
+	strcpy(path_buffer, original_path);
+	strcat(path_buffer, extension);
+
+	return true;
+}
 
 bool 
 file_is_compressed_type(char const *path)
@@ -16,35 +46,264 @@ file_is_compressed_type(char const *path)
 	return false;
 }
 
-int 
-gzsize(gzFile f)
+void
+files_shutdown()
 {
-	int oldseek = gztell(f);
-	gzseek(f, 0, SEEK_SET);
+	struct x16file *f = open_files;
+	struct x16file *next_f = f ? f->next : NULL;
+	for(; f != NULL; f = next_f) {
+		next_f = f->next;
 
-	uint8_t read_buffer[64 * 1024];
-	int  total_bytes = 0;
-	int  bytes_read  = 0;
+		SDL_RWclose(f->file);
+		free(f);
+	}
+}
 
-	do {
-		bytes_read = gzread(f, read_buffer, 64 * 1024);
-		total_bytes += bytes_read;
-	} while (bytes_read == 64 * 1024);
+struct x16file *
+x16open(const char *path, const char *attribs)
+{
+	struct x16file *f = malloc(sizeof(struct x16file));
+	strcpy(f->path, path);
 
-	gzseek(f, oldseek, SEEK_SET);
-	return total_bytes;
+	if(file_is_compressed_type(path)) {
+		char tmp_path[PATH_MAX];
+		if(!get_tmp_name(tmp_path, path, ".tmp")) {
+			printf("Path too long, cannot create temp file: %s\n", path);
+			goto error;
+		}
+
+		gzFile zfile = gzopen(path, "rb");
+		if(zfile == Z_NULL) {
+			printf("Could not open file for decompression: %s\n", path);
+			goto error;
+		}
+
+		SDL_RWops *tfile = SDL_RWFromFile(tmp_path, "wb");
+		if(tfile == NULL) {
+			gzclose(zfile);
+			printf("Could not open file for write: %s\n", tmp_path);
+			goto error;
+		}
+
+		const int buffer_size = 16 * 1024 * 1024;
+		char *buffer = malloc(buffer_size);
+
+		int read = gzread(zfile, buffer, buffer_size);
+		int64_t total_read = read;
+		while(read > 0) {
+			SDL_RWwrite(tfile, buffer, read, 1);
+			read = gzread(zfile, buffer, buffer_size);
+			total_read += read;
+		}
+
+		SDL_RWclose(tfile);
+		gzclose(zfile);
+		free(buffer);
+
+		f->file = SDL_RWFromFile(tmp_path, attribs);
+		f->size = total_read;
+	} else {
+		f->file = SDL_RWFromFile(path, attribs);
+		f->size = SDL_RWsize(f->file);
+	}
+	f->pos = 0;
+	f->next = open_files ? open_files : NULL;
+	open_files = f;
+
+	return f;
+
+error:
+	free(f);
+	return NULL;
+}
+
+void 
+x16close(struct x16file *f)
+{
+	if(f == NULL) {
+		return;
+	}
+
+	SDL_RWclose(f->file);
+
+	if(file_is_compressed_type(f->path)) {
+		char tmp_path[PATH_MAX];
+		if(!get_tmp_name(tmp_path, f->path, ".tmp")) {
+			printf("Path too long, cannot create temp file: %s\n", f->path);
+			goto zfile_error;
+		}
+
+		gzFile zfile = gzopen(f->path, "wb9");
+		if(zfile == Z_NULL) {
+			printf("Could not open file for compression: %s\n", f->path);
+			goto zfile_error;
+		}
+
+		SDL_RWops *tfile = SDL_RWFromFile(tmp_path, "rb");
+		if(tfile == NULL) {
+			gzclose(zfile);
+			printf("Could not open file for read: %s\n", tmp_path);
+			goto tfile_error;
+		}
+
+		const int buffer_size = 16 * 1024 * 1024;
+		char *buffer = malloc(buffer_size);
+
+		int read = SDL_RWread(tfile, buffer, 1, buffer_size);
+		int64_t total_read = read;
+		while(read > 0) {
+			gzwrite(zfile, buffer, read);
+			read = SDL_RWread(tfile, buffer, 1, buffer_size);
+			total_read += read;
+		}
+
+		free(buffer);
+
+		if(tfile != NULL) {
+			SDL_RWclose(tfile);
+		}
+
+	tfile_error:
+		if(zfile != Z_NULL) {
+			gzclose(zfile);
+		}
+	}
+zfile_error:
+	free(f);
+}
+
+int64_t 
+x16size(struct x16file *f)
+{
+	if(f == NULL) {
+		return 0;
+	}
+
+	return f->size;
 }
 
 int 
-gzwrite8(gzFile f, uint8_t val)
+x16seek(struct x16file *f, int64_t pos, int origin)
 {
-	return gzwrite(f, &val, 1);
+	if(f == NULL) {
+		return 0;
+	}
+	switch(origin) {
+		case SEEK_SET:
+			f->pos = (pos > f->size) ? f->size : pos;
+			break;
+		case SEEK_CUR:
+			f->pos += pos;
+			if(f->pos > f->size || f->pos < 0) {
+				f->pos = f->size;
+			}
+			break;
+		case SEEK_END:
+			f->pos = f->size - pos;
+			if(f->pos < 0) {
+				f->pos = f->size;
+			}
+	}
+	return SDL_RWseek(f->file, f->pos, SEEK_SET);
+}
+
+int64_t 
+x16tell(struct x16file *f)
+{
+	if(f == NULL) {
+		return 0;
+	}
+	return f->pos;
 }
 
 int 
-gzread8(gzFile f)
+x16write8(struct x16file *f, uint8_t val)
 {
-	uint8_t value;
-	gzread(f, &value, 1);
-	return value;
+	if(f == NULL) {
+		return 0;
+	}
+	int written = SDL_RWwrite(f->file, &val, 1, 1);
+	f->pos += written;
+	return written;
+}
+
+int 
+x16write16(struct x16file *f, uint16_t val)
+{
+	if(f == NULL) {
+		return 0;
+	}
+	int written = SDL_RWwrite(f->file, &val, 1, 2);
+	f->pos += written;
+	return written;
+}
+
+int 
+x16write32(struct x16file *f, uint32_t val)
+{
+	if(f == NULL) {
+		return 0;
+	}
+	int written = SDL_RWwrite(f->file, &val, 1, 4);
+	f->pos += written;
+	return written;
+}
+
+uint8_t 
+x16read8(struct x16file *f)
+{
+	if(f == NULL) {
+		return 0;
+	}
+	uint8_t val;
+	int read = SDL_RWread(f->file, &val, 1, 1);
+	f->pos += read;
+	return read;
+}
+
+uint16_t 
+x16read16(struct x16file *f)
+{
+	if(f == NULL) {
+		return 0;
+	}
+	uint16_t val;
+	int read = SDL_RWread(f->file, &val, 1, 2);
+	f->pos += read;
+	return read;
+}
+
+uint32_t 
+x16read32(struct x16file *f)
+{
+	if(f == NULL) {
+		return 0;
+	}
+	uint32_t val;
+	int read = SDL_RWread(f->file, &val, 1, 4);
+	f->pos += read;
+	return read;
+}
+
+
+uint64_t 
+x16write(struct x16file *f, const uint8_t *data, uint64_t data_size, uint64_t data_count)
+{
+	if(f == NULL) {
+		return 0;
+	}
+	int64_t written = SDL_RWwrite(f->file, data, data_size, data_count);
+	f->pos += written * data_size;
+	return written;
+}
+
+uint64_t 
+x16read(struct x16file *f, uint8_t *data, uint64_t data_size, uint64_t data_count)
+{
+	if(f == NULL) {
+		return 0;
+	}
+	int64_t read = SDL_RWread(f->file, data, data_size, data_count);
+	f->pos += read * data_size;
+	return read;
 }

--- a/src/files.c
+++ b/src/files.c
@@ -208,6 +208,16 @@ x16close(struct x16file *f)
 		unlink(tmp_path);
 	}
 tmp_path_error:
+	if(f == open_files) {
+		open_files = f->next;
+	} else {
+		for(struct x16file *fi = open_files; fi != NULL; fi = fi->next) {
+			if(fi->next == f) {
+				fi->next = f->next;
+				break;
+			}
+		}
+	}
 	free(f);
 }
 

--- a/src/files.c
+++ b/src/files.c
@@ -102,14 +102,14 @@ x16open(const char *path, const char *attribs)
 		int64_t progress_threshold = progress_increment;
 		while(read > 0) {
 			if(total_read > progress_threshold) {
-				printf(PRId64 " MB\n", total_read / (1024 * 1024));
+				printf("%" PRId64 " MB\n", total_read / (1024 * 1024));
 				progress_threshold += progress_increment;
 			}
 			SDL_RWwrite(tfile, buffer, read, 1);
 			read = gzread(zfile, buffer, buffer_size);
 			total_read += read;
 		}
-		printf(PRId64 " MB\n", total_read / (1024 * 1024));
+		printf("%" PRId64 " MB\n", total_read / (1024 * 1024));
 
 		SDL_RWclose(tfile);
 		gzclose(zfile);

--- a/src/files.c
+++ b/src/files.c
@@ -156,11 +156,9 @@ x16close(struct x16file *f)
 		char *buffer = malloc(buffer_size);
 
 		int read = SDL_RWread(tfile, buffer, 1, buffer_size);
-		int64_t total_read = read;
 		while(read > 0) {
 			gzwrite(zfile, buffer, read);
 			read = SDL_RWread(tfile, buffer, 1, buffer_size);
-			total_read += read;
 		}
 
 		free(buffer);

--- a/src/files.c
+++ b/src/files.c
@@ -160,7 +160,7 @@ x16close(struct x16file *f)
 			goto zfile_clean;
 		}
 
-		gzFile zfile = gzopen(f->path, "wb9");
+		gzFile zfile = gzopen(f->path, "wb6");
 		if(zfile == Z_NULL) {
 			printf("Could not open file for compression: %s\n", f->path);
 			goto zfile_error;
@@ -276,28 +276,6 @@ x16write8(struct x16file *f, uint8_t val)
 	return written;
 }
 
-int 
-x16write16(struct x16file *f, uint16_t val)
-{
-	if(f == NULL) {
-		return 0;
-	}
-	int written = SDL_RWwrite(f->file, &val, 1, 2);
-	f->pos += written;
-	return written;
-}
-
-int 
-x16write32(struct x16file *f, uint32_t val)
-{
-	if(f == NULL) {
-		return 0;
-	}
-	int written = SDL_RWwrite(f->file, &val, 1, 4);
-	f->pos += written;
-	return written;
-}
-
 uint8_t 
 x16read8(struct x16file *f)
 {
@@ -309,31 +287,6 @@ x16read8(struct x16file *f)
 	f->pos += read;
 	return read;
 }
-
-uint16_t 
-x16read16(struct x16file *f)
-{
-	if(f == NULL) {
-		return 0;
-	}
-	uint16_t val;
-	int read = SDL_RWread(f->file, &val, 1, 2);
-	f->pos += read;
-	return read;
-}
-
-uint32_t 
-x16read32(struct x16file *f)
-{
-	if(f == NULL) {
-		return 0;
-	}
-	uint32_t val;
-	int read = SDL_RWread(f->file, &val, 1, 4);
-	f->pos += read;
-	return read;
-}
-
 
 uint64_t 
 x16write(struct x16file *f, const uint8_t *data, uint64_t data_size, uint64_t data_count)

--- a/src/files.c
+++ b/src/files.c
@@ -10,6 +10,7 @@
 #include <stdlib.h>
 #include <SDL.h>
 #include <zlib.h>
+#include <inttypes.h>
 
 struct x16file
 {
@@ -101,14 +102,14 @@ x16open(const char *path, const char *attribs)
 		int64_t progress_threshold = progress_increment;
 		while(read > 0) {
 			if(total_read > progress_threshold) {
-				printf("%ld MB\n", total_read / (1024 * 1024));
+				printf(PRId64 " MB\n", total_read / (1024 * 1024));
 				progress_threshold += progress_increment;
 			}
 			SDL_RWwrite(tfile, buffer, read, 1);
 			read = gzread(zfile, buffer, buffer_size);
 			total_read += read;
 		}
-		printf("%ld MB\n", total_read / (1024 * 1024));
+		printf(PRId64 " MB\n", total_read / (1024 * 1024));
 
 		SDL_RWclose(tfile);
 		gzclose(zfile);

--- a/src/files.c
+++ b/src/files.c
@@ -1,0 +1,50 @@
+#include "files.h"
+
+#include <string.h>
+
+bool 
+file_is_compressed_type(char const *path)
+{
+	int len = (int)strlen(path);
+
+	if (strcmp(path + len - 3, ".gz") == 0 || strcmp(path + len - 3, "-gz") == 0) {
+		return true;
+	} else if (strcmp(path + len - 2, ".z") == 0 || strcmp(path + len - 2, "-z") == 0 || strcmp(path + len - 2, "_z") == 0 || strcmp(path + len - 2, ".Z") == 0) {
+		return true;
+	}
+
+	return false;
+}
+
+int 
+gzsize(gzFile f)
+{
+	int oldseek = gztell(f);
+	gzseek(f, 0, SEEK_SET);
+
+	uint8_t read_buffer[64 * 1024];
+	int  total_bytes = 0;
+	int  bytes_read  = 0;
+
+	do {
+		bytes_read = gzread(f, read_buffer, 64 * 1024);
+		total_bytes += bytes_read;
+	} while (bytes_read == 64 * 1024);
+
+	gzseek(f, oldseek, SEEK_SET);
+	return total_bytes;
+}
+
+int 
+gzwrite8(gzFile f, uint8_t val)
+{
+	return gzwrite(f, &val, 1);
+}
+
+int 
+gzread8(gzFile f)
+{
+	uint8_t value;
+	gzread(f, &value, 1);
+	return value;
+}

--- a/src/files.h
+++ b/src/files.h
@@ -1,0 +1,10 @@
+#include <stdbool.h>
+#include <stdint.h>
+#include <zlib.h>
+
+bool file_is_compressed_type(char const *path);
+
+// SDL-like functions to ease substitution of gz for SDL_RW
+int gzsize(gzFile f);
+int gzwrite8(gzFile f, uint8_t val);
+int gzread8(gzFile f);

--- a/src/files.h
+++ b/src/files.h
@@ -1,10 +1,31 @@
 #include <stdbool.h>
 #include <stdint.h>
-#include <zlib.h>
+
+struct x16file;
+
+#define XSEEK_SET	0
+#define XSEEK_END	1
+#define XSEEK_CUR	2
 
 bool file_is_compressed_type(char const *path);
 
-// SDL-like functions to ease substitution of gz for SDL_RW
-int gzsize(gzFile f);
-int gzwrite8(gzFile f, uint8_t val);
-int gzread8(gzFile f);
+void files_shutdown();
+
+struct x16file *x16open(const char *path, const char *attribs);
+void x16close(struct x16file *f);
+
+int64_t x16size(struct x16file *f);
+int x16seek(struct x16file *f, int64_t pos, int origin);
+int64_t x16tell(struct x16file *f);
+
+
+int x16write8(struct x16file *f, uint8_t val);
+int x16write16(struct x16file *f, uint16_t val);
+int x16write32(struct x16file *f, uint32_t val);
+
+uint8_t x16read8(struct x16file *f);
+uint16_t x16read16(struct x16file *f);
+uint32_t x16read32(struct x16file *f);
+
+uint64_t x16write(struct x16file *f, const uint8_t *data, uint64_t data_size, uint64_t data_count);
+uint64_t x16read(struct x16file *f, uint8_t *data, uint64_t data_size, uint64_t data_count);

--- a/src/files.h
+++ b/src/files.h
@@ -20,12 +20,7 @@ int64_t x16tell(struct x16file *f);
 
 
 int x16write8(struct x16file *f, uint8_t val);
-int x16write16(struct x16file *f, uint16_t val);
-int x16write32(struct x16file *f, uint32_t val);
-
 uint8_t x16read8(struct x16file *f);
-uint16_t x16read16(struct x16file *f);
-uint32_t x16read32(struct x16file *f);
 
 uint64_t x16write(struct x16file *f, const uint8_t *data, uint64_t data_size, uint64_t data_count);
 uint64_t x16read(struct x16file *f, uint8_t *data, uint64_t data_size, uint64_t data_count);

--- a/src/main.c
+++ b/src/main.c
@@ -19,6 +19,7 @@
 #include "cpu/fake6502.h"
 #include "timing.h"
 #include "disasm.h"
+#include "files.h"
 #include "memory.h"
 #include "video.h"
 #include "via.h"
@@ -917,7 +918,6 @@ main(int argc, char **argv)
 		}
 	}
 
-	sdcard_init();
 	if (sdcard_path) {
 		sdcard_set_path(sdcard_path);
 	}
@@ -992,13 +992,13 @@ main(int argc, char **argv)
 	emulator_loop(NULL);
 #endif
 
-	sdcard_shutdown();
 	if (!headless){
 		wav_recorder_shutdown();
 		audio_close();
 		video_end();
 		SDL_Quit();
 	}
+	files_shutdown();
 
 #ifdef PERFSTAT
 	for (int pc = 0xc000; pc < sizeof(stat)/sizeof(*stat); pc++) {

--- a/src/main.c
+++ b/src/main.c
@@ -918,12 +918,7 @@ main(int argc, char **argv)
 	}
 
 	if (sdcard_path) {
-		sdcard_file = SDL_RWFromFile(sdcard_path, "r+b");
-		if (!sdcard_file) {
-			printf("Cannot open %s!\n", sdcard_path);
-			exit(1);
-		}
-		sdcard_attach();
+		sdcard_set_path(sdcard_path);
 	}
 
 	prg_override_start = -1;
@@ -997,6 +992,7 @@ main(int argc, char **argv)
 #endif
 
 	if (!headless){
+		sdcard_shutdown();
 		wav_recorder_shutdown();
 		audio_close();
 		video_end();
@@ -1091,13 +1087,13 @@ handle_ieee_intercept()
 		return false;
 	}
 
-	if (sdcard_file && !prg_file) {
+	if (sdcard_is_attached() && !prg_file) {
 		// if should emulate an SD card (and don't need to
 		// hack a PRG into RAM), we'll always skip host fs
 		return false;
 	}
 
-	if (sdcard_file && prg_file && prg_finished_loading) {
+	if (sdcard_is_attached() && prg_file && prg_finished_loading) {
 		// also skip if we should do SD card and we're done
 		// with the PRG hack
 		return false;
@@ -1138,7 +1134,7 @@ handle_ieee_intercept()
 			break;
 		case 0xFFAE:
 			s=UNLSN();
-			if (prg_file && sdcard_file && ++count_unlistn == 4) {
+			if (prg_file && sdcard_path_is_set() && ++count_unlistn == 4) {
 				// after auto-loading a PRG from the host fs,
 				// switch to the SD card if requested
 				// 4x UNLISTEN:

--- a/src/main.c
+++ b/src/main.c
@@ -992,8 +992,8 @@ main(int argc, char **argv)
 	emulator_loop(NULL);
 #endif
 
+	sdcard_shutdown();
 	if (!headless){
-		sdcard_shutdown();
 		wav_recorder_shutdown();
 		audio_close();
 		video_end();

--- a/src/main.c
+++ b/src/main.c
@@ -917,6 +917,7 @@ main(int argc, char **argv)
 		}
 	}
 
+	sdcard_init();
 	if (sdcard_path) {
 		sdcard_set_path(sdcard_path);
 	}
@@ -1087,13 +1088,13 @@ handle_ieee_intercept()
 		return false;
 	}
 
-	if (sdcard_is_attached() && !prg_file) {
+	if (sdcard_attached && !prg_file) {
 		// if should emulate an SD card (and don't need to
 		// hack a PRG into RAM), we'll always skip host fs
 		return false;
 	}
 
-	if (sdcard_is_attached() && prg_file && prg_finished_loading) {
+	if (sdcard_attached && prg_file && prg_finished_loading) {
 		// also skip if we should do SD card and we're done
 		// with the PRG hack
 		return false;

--- a/src/sdcard.c
+++ b/src/sdcard.c
@@ -84,7 +84,8 @@ sdcard_hash(int key)
 	return (key * 0x9e3779b9) >> 23;
 }
 
-static bool sdcard_table_is_dense()
+static bool 
+sdcard_table_is_dense()
 {
 	return sdcard_changes.num_contained > (MAX_TABLE_ENTRIES >> 1);
 }
@@ -236,12 +237,6 @@ sdcard_detach()
 		printf("SD card detached.\n");
 		sdcard_attached = false;
 	}
-}
-
-bool
-sdcard_is_attached()
-{
-	return (sdcard_file != Z_NULL) && sdcard_attached;
 }
 
 void

--- a/src/sdcard.c
+++ b/src/sdcard.c
@@ -2,7 +2,8 @@
 // Copyright (c) 2019 Michael Steil
 // Copyright (c) 2020 Frank van den Hoef
 // All rights reserved. License: 2-clause BSD
-
+#define _POSIX_C_SOURCE 1
+#include <limits.h>
 #include <stdio.h>
 #include <stdbool.h>
 #include "sdcard.h"

--- a/src/sdcard.c
+++ b/src/sdcard.c
@@ -2,6 +2,11 @@
 // Copyright (c) 2019 Michael Steil
 // Copyright (c) 2020 Frank van den Hoef
 // All rights reserved. License: 2-clause BSD
+#ifndef __APPLE__
+#define _XOPEN_SOURCE   600
+#define _POSIX_C_SOURCE 1
+#endif
+
 #include <limits.h>
 #include <stdio.h>
 #include <stdbool.h>

--- a/src/sdcard.c
+++ b/src/sdcard.c
@@ -2,7 +2,10 @@
 // Copyright (c) 2019 Michael Steil
 // Copyright (c) 2020 Frank van den Hoef
 // All rights reserved. License: 2-clause BSD
+#ifndef __APPLE__
+#define _XOPEN_SOURCE   600
 #define _POSIX_C_SOURCE 1
+#endif
 #include <limits.h>
 #include <stdio.h>
 #include <stdbool.h>

--- a/src/sdcard.c
+++ b/src/sdcard.c
@@ -180,13 +180,13 @@ void
 sdcard_attach()
 {
 	if (!sdcard_attached && sdcard_path_is_set()) {
-		gzFile f = gzopen(sdcard_path, "rb");
-		if(f == Z_NULL) {
+		sdcard_file = gzopen(sdcard_path, "rb");
+		if(sdcard_file == Z_NULL) {
 			printf("Cannot open SDCard file %s!\n", sdcard_path);
 			return;
 		}
 
-		sdcard_size = gzsize(f);
+		sdcard_size = gzsize(sdcard_file);
 		sdcard_table_clear();
 
 		printf("SD card attached.\n");

--- a/src/sdcard.c
+++ b/src/sdcard.c
@@ -79,7 +79,7 @@ void
 sdcard_attach()
 {
 	if (!sdcard_attached && sdcard_path_is_set()) {
-		sdcard_file = x16open(sdcard_path, "rb");
+		sdcard_file = x16open(sdcard_path, "r+b");
 		if(sdcard_file == NULL) {
 			printf("Cannot open SDCard file %s!\n", sdcard_path);
 			return;

--- a/src/sdcard.c
+++ b/src/sdcard.c
@@ -240,7 +240,7 @@ sdcard_handle(uint8_t inbyte)
 						read_block_response[1] = 0x08; // out of range
 						response_length = 2;
 					} else {
-						x16seek(sdcard_file, (Sint64)lba * 512, SEEK_SET);
+						x16seek(sdcard_file, (Sint64)lba * 512, XSEEK_SET);
 						int bytes_read = x16read(sdcard_file, &read_block_response[2], 1, 512);
 						if (bytes_read != 512) {
 							printf("Warning: short read!\n");
@@ -302,7 +302,7 @@ sdcard_handle(uint8_t inbyte)
 				if ((Sint64)lba * 512 >= x16size(sdcard_file)) {
 					// do nothing?
 				} else {
-					x16seek(sdcard_file, (Sint64)lba * 512, SEEK_SET);
+					x16seek(sdcard_file, (Sint64)lba * 512, XSEEK_SET);
 					int bytes_written = x16write(sdcard_file, rxbuf + 1, 1, 512);
 					if (bytes_written != 512) {
 						printf("Warning: short write!\n");

--- a/src/sdcard.c
+++ b/src/sdcard.c
@@ -413,17 +413,17 @@ sdcard_handle(uint8_t inbyte)
 						read_block_response[1] = 0x08; // out of range
 						response_length = 2;
 					} else {
-            int sdcard_pos = lba * 512;
-            int remaining = sdcard_size - sdcard_pos;
-            if (remaining < 512) {
-              printf("Warning: short read!");
-            }
-            if (sdcard_table_contains(lba)) {
-              memcpy(&read_block_response[2], sdcard_table_get(lba), (remaining < 512 ? remaining : 512));
-            } else {
-              gzseek(sdcard_file, sdcard_pos, SEEK_SET);
-              gzread(sdcard_file, &read_block_response[2], 512);
-            }
+						int sdcard_pos = lba * 512;
+						int remaining = sdcard_size - sdcard_pos;
+						if (remaining < 512) {
+							printf("Warning: short read!");
+						}
+						if (sdcard_table_contains(lba)) {
+							memcpy(&read_block_response[2], sdcard_table_get(lba), (remaining < 512 ? remaining : 512));
+						} else {
+							gzseek(sdcard_file, sdcard_pos, SEEK_SET);
+							gzread(sdcard_file, &read_block_response[2], 512);
+						}
 						response = read_block_response;
 						response_length = 2 + 512 + 2;
 					}
@@ -480,16 +480,16 @@ sdcard_handle(uint8_t inbyte)
 				if ((Sint64)lba * 512 >= sdcard_size) {
 					// do nothing?
 				} else {
-          int sdcard_pos = lba * 512;
-          int remaining = sdcard_size - sdcard_pos;
-          if(remaining < 512) {
-            printf("Warning: short write!\n");
-          }
-          memcpy(sdcard_table_get(lba), rxbuf + 1, remaining < 512 ? remaining : 512);
-          if(sdcard_table_is_dense()) {
-            sdcard_swap(true);
-          }
-        }
+					int sdcard_pos = lba * 512;
+					int remaining = sdcard_size - sdcard_pos;
+					if(remaining < 512) {
+						printf("Warning: short write!\n");
+					}
+					memcpy(sdcard_table_get(lba), rxbuf + 1, remaining < 512 ? remaining : 512);
+					if(sdcard_table_is_dense()) {
+						sdcard_swap(true);
+					}
+				}
 			}
 		}
 	}

--- a/src/sdcard.c
+++ b/src/sdcard.c
@@ -47,8 +47,7 @@ struct lba_block {
 	struct lba_block *next;
 };
 
-//#define MAX_TABLE_ENTRIES (128 * 1024)
-#define MAX_TABLE_ENTRIES (32)
+#define MAX_TABLE_ENTRIES (128 * 1024) // Suggest sizing this down to something reasonable like "32" when testing.
 
 struct changed_blocks_table
 {

--- a/src/sdcard.c
+++ b/src/sdcard.c
@@ -2,14 +2,9 @@
 // Copyright (c) 2019 Michael Steil
 // Copyright (c) 2020 Frank van den Hoef
 // All rights reserved. License: 2-clause BSD
-#ifndef __APPLE__
-#define _XOPEN_SOURCE   600
-#define _POSIX_C_SOURCE 1
-#endif
 #include <limits.h>
 #include <stdio.h>
 #include <stdbool.h>
-#include <string.h>
 #include "sdcard.h"
 #include "files.h"
 

--- a/src/sdcard.h
+++ b/src/sdcard.h
@@ -8,12 +8,12 @@
 #include <SDL.h>
 
 extern bool sdcard_attached;
+void sdcard_init();
 void sdcard_shutdown();
 void sdcard_set_path(char const *path);
 bool sdcard_path_is_set();
 void sdcard_attach();
 void sdcard_detach();
-bool sdcard_is_attached();
 
 void sdcard_select(bool select);
 uint8_t sdcard_handle(uint8_t inbyte);

--- a/src/sdcard.h
+++ b/src/sdcard.h
@@ -7,11 +7,13 @@
 #include <stdbool.h>
 #include <SDL.h>
 
-extern SDL_RWops *sdcard_file;
 extern bool sdcard_attached;
-
+void sdcard_shutdown();
+void sdcard_set_path(char const *path);
+bool sdcard_path_is_set();
 void sdcard_attach();
 void sdcard_detach();
+bool sdcard_is_attached();
 
 void sdcard_select(bool select);
 uint8_t sdcard_handle(uint8_t inbyte);

--- a/src/sdcard.h
+++ b/src/sdcard.h
@@ -8,8 +8,6 @@
 #include <SDL.h>
 
 extern bool sdcard_attached;
-void sdcard_init();
-void sdcard_shutdown();
 void sdcard_set_path(char const *path);
 bool sdcard_path_is_set();
 void sdcard_attach();


### PR DESCRIPTION
Zlib support for sdcard images. Since compressed files can only be open for read or for write, and writes cannot occur into the middle of a gzipped file, this stores changed blocks in a hash table. Once changes start to consume a significant fraction of the hash table, a temporary file is written and re-mounted as the new SD card image so that the table can be flushed. If such a temporary file is generated, it is cleaned up at system exit.