### PR TITLE
Add Scroll Lock to the list of supported SDL -> PS/2 scancodes

### DIFF
--- a/src/keyboard.c
+++ b/src/keyboard.c
@@ -168,6 +168,8 @@ ps2_scancode_from_SDL_Scancode(SDL_Scancode scancode)
 			return 0x78;
 		case SDL_SCANCODE_F12:
 			return 0x07;
+		case SDL_SCANCODE_SCROLLLOCK:
+			return 0x7e;
 		case SDL_SCANCODE_RSHIFT:
 			return 0x59;
 		case SDL_SCANCODE_LSHIFT:


### PR DESCRIPTION
Scroll lock is the 40/80 key on hardware.  This change adds it so that it is recognized in the emu.

However, while this seems to work flawlessly on Linux, it seems that Windows captures this key somehow, at least on my machine.  I could use some further tests and/or advice here.