### PR TITLE
Mirror STATUS byte behavior for host filesystem, fix off-by-one error on ACPTR/EOI

### DIFF
--- a/src/ieee.h
+++ b/src/ieee.h
@@ -3,7 +3,7 @@
 // All rights reserved. License: 2-clause BSD
 
 void ieee_init();
-void SECOND(uint8_t a);
+int SECOND(uint8_t a);
 void TKSA(uint8_t a);
 int ACPTR(uint8_t *a);
 int CIOUT(uint8_t a);

--- a/src/main.c
+++ b/src/main.c
@@ -1144,7 +1144,7 @@ handle_ieee_intercept()
 			break;
 		}
 		case 0xFF93:
-			SECOND(a);
+			s=SECOND(a);
 			break;
 		case 0xFF96:
 			TKSA(a);


### PR DESCRIPTION
This work was triggered by a mention from Jestin that VERIFY/BVERIFY fail on host filesystem.

This led me to realize that we need ACPTR to report EOI while delivering the last byte, contrary to POSIX behavior.  Since we support mixed access and seeking, it is by far the easiest to check the position relative to the EOF on every read.

This PR also includes changes which set the STATUS byte (ieee_status) in ways that mirror the ROM's behavior for the low level IEEE commands.