### PR TITLE
[VIDEO] implement lineirq timing to more closely match hardware VERA behavior

### DIFF
--- a/src/cpu/fake6502.c
+++ b/src/cpu/fake6502.c
@@ -77,7 +77,7 @@
  * void step6502()                                   *
  *   - Execute a single instrution.                  *
  *                                                   *
- * void irq6502()                                    *
+ * bool irq6502()                                    *
  *   - Trigger a hardware IRQ in the 6502 core.      *
  *                                                   *
  * void nmi6502()                                    *
@@ -104,6 +104,7 @@
 
 #include <stdio.h>
 #include <stdint.h>
+#include <stdbool.h>
 
 //6502 defines
 #define UNDOCUMENTED //when this is defined, undocumented opcodes are handled.
@@ -175,18 +176,23 @@ void nmi6502() {
     setinterrupt();
     cleardecimal();
     pc = (uint16_t)read6502(0xFFFA) | ((uint16_t)read6502(0xFFFB) << 8);
+    clockticks6502 += 7; // consumed by CPU to process interrupt
     waiting = 0;
 }
 
-void irq6502() {
+bool irq6502() {
+    bool ret = false;
     if (!(status & FLAG_INTERRUPT)) {
         push16(pc);
         push8(status & ~FLAG_BREAK);
         setinterrupt();
         cleardecimal();
         pc = (uint16_t)read6502(0xFFFE) | ((uint16_t)read6502(0xFFFF) << 8);
+        clockticks6502 += 7; // consumed by CPU to process interrupt
+        ret = true;
     }
     waiting = 0;
+    return ret;
 }
 
 uint8_t callexternal = 0;

--- a/src/cpu/fake6502.c
+++ b/src/cpu/fake6502.c
@@ -104,7 +104,6 @@
 
 #include <stdio.h>
 #include <stdint.h>
-#include <stdbool.h>
 
 //6502 defines
 #define UNDOCUMENTED //when this is defined, undocumented opcodes are handled.
@@ -180,8 +179,7 @@ void nmi6502() {
     waiting = 0;
 }
 
-bool irq6502() {
-    bool ret = false;
+void irq6502() {
     if (!(status & FLAG_INTERRUPT)) {
         push16(pc);
         push8(status & ~FLAG_BREAK);
@@ -189,10 +187,8 @@ bool irq6502() {
         cleardecimal();
         pc = (uint16_t)read6502(0xFFFE) | ((uint16_t)read6502(0xFFFF) << 8);
         clockticks6502 += 7; // consumed by CPU to process interrupt
-        ret = true;
     }
     waiting = 0;
-    return ret;
 }
 
 uint8_t callexternal = 0;

--- a/src/cpu/fake6502.c
+++ b/src/cpu/fake6502.c
@@ -77,7 +77,7 @@
  * void step6502()                                   *
  *   - Execute a single instrution.                  *
  *                                                   *
- * bool irq6502()                                    *
+ * void irq6502()                                    *
  *   - Trigger a hardware IRQ in the 6502 core.      *
  *                                                   *
  * void nmi6502()                                    *

--- a/src/cpu/fake6502.h
+++ b/src/cpu/fake6502.h
@@ -10,7 +10,7 @@
 extern void reset6502();
 extern void step6502();
 extern void exec6502(uint32_t tickcount);
-extern bool irq6502();
+extern void irq6502();
 extern void nmi6502();
 extern uint32_t clockticks6502;
 

--- a/src/cpu/fake6502.h
+++ b/src/cpu/fake6502.h
@@ -10,7 +10,7 @@
 extern void reset6502();
 extern void step6502();
 extern void exec6502(uint32_t tickcount);
-extern void irq6502();
+extern bool irq6502();
 extern void nmi6502();
 extern uint32_t clockticks6502;
 

--- a/src/main.c
+++ b/src/main.c
@@ -1366,7 +1366,7 @@ emulator_loop(void *param)
 		if (video_get_irq_out() || via1_irq() || (has_via2 && via2_irq())) {
 //			printf("IRQ!\n");
 			irq6502();
-		}			
+		}
 
 		if (pc == 0xffff) {
 			if (save_on_exit) {

--- a/src/video.h
+++ b/src/video.h
@@ -13,7 +13,7 @@
 
 bool video_init(int window_scale, double screen_x_scale,  char *quality);
 void video_reset(void);
-bool video_step(float mhz, float steps);
+bool video_step(float mhz, float steps, bool midline);
 bool video_update(void);
 void video_end(void);
 bool video_get_irq_out(void);


### PR DESCRIPTION
This change:

* factors in IRQ/NMI cycle times in the step delays (7 clocks)
* emulates the distinct render and scanout behaviors of VERA by creating a two-line history for the layer parameters and composer values, so that the lookups can happen later (as if they were applied during an earlier render cycle).  Properties which have this apparent delay include HSCROLL and VSCROLL
* changes the nature of VSCALE and HSCALE increments into accumulators for the frame and line respectively, rather than doing absolute lookups each scanline
* causes a mid-line render update immediately before events which could indeed change the composer or layer properties, or writes to VRAM including palette.
* like old behavior, at the end of each scanline, the line is rendered, but instead of the whole line, it's the part of the line that hasn't yet been rendered.  If there were no events that triggered a partial scanline render, the whole line is rendered as before.

This is not 100% cycle accurate to hardware yet, but it's much closer to HW behavior, and should no longer catch people out.