### PR TITLE
[VIDEO] layer properties check here needs to be the delayed version

### DIFF
--- a/src/video.c
+++ b/src/video.c
@@ -940,18 +940,18 @@ render_line(uint16_t y, float scan_pos_x)
 	}
 
 	if (layer_line_enable[0]) {
-		if (layer_properties[0].text_mode) {
+		if (prev_layer_properties[1][0].text_mode) {
 			render_layer_line_text(0, eff_y);
-		} else if (layer_properties[0].bitmap_mode) {
+		} else if (prev_layer_properties[1][0].bitmap_mode) {
 			render_layer_line_bitmap(0, eff_y);
 		} else {
 			render_layer_line_tile(0, eff_y);
 		}
 	}
 	if (layer_line_enable[1]) {
-		if (layer_properties[1].text_mode) {
+		if (prev_layer_properties[1][1].text_mode) {
 			render_layer_line_text(1, eff_y);
-		} else if (layer_properties[1].bitmap_mode) {
+		} else if (prev_layer_properties[1][1].bitmap_mode) {
 			render_layer_line_bitmap(1, eff_y);
 		} else {
 			render_layer_line_tile(1, eff_y);


### PR DESCRIPTION
PETSCII ROBOTS does layer changes with a timing that exposed this bug, so that the delayed version of the layer properties was not initialized with the correct layer parameters.  It caused a Floating Point Exception when trying to run X16 ROBOTS.

gdb was useful in finding the line that triggered the crash.  `props->tileh` was zero here.

```
Using host libthread_db library "/lib64/libthread_db.so.1".
Core was generated by `x16emu'.
Program terminated with signal SIGFPE, Arithmetic exception.

warning: Section `.reg-xstate/2448093' in core file too small.
#0  0x00005651ce4be076 in render_layer_line_bitmap (layer=0 '\000', y=108) at src/video.c:781
781		int yy = y % props->tileh;
[Current thread is 1 (Thread 0x7fddd666d800 (LWP 2448093))]
```