### PR TITLE
[MEMORY/DEBUGGER] Implement open bus behavior for unconnected banks, fix debugger disasm wrap

### DIFF
--- a/src/debugger.c
+++ b/src/debugger.c
@@ -607,7 +607,7 @@ static void DEBUGRenderCode(int lines, int initialPC) {
 		int size = disasm(initialPC, RAM, buffer, sizeof(buffer), true, currentPCBank);	// Disassemble code
 		// Output assembly highlighting PC
 		DEBUGString(dbgRenderer, DBG_ASMX+8, y, buffer, initialPC == pc ? col_highlight : col_data);
-		initialPC += size;										// Forward to next
+		initialPC = (initialPC + size) & 0xffff;										// Forward to next
 	}
 }
 

--- a/src/glue.h
+++ b/src/glue.h
@@ -22,6 +22,8 @@
 #define ROM_SIZE (NUM_ROM_BANKS * 16384)   /* banks at $C000-$FFFF */
 #define CART_SIZE (NUM_CART_BANKS * 16384)  /* expansion banks at $C000-$FFFF */
 
+#define OPEN_BUS_READ 0xC0 // Proto 4 open data bus read behavior, according to David Murray
+
 typedef enum {
 	ECHO_MODE_NONE,
 	ECHO_MODE_RAW,


### PR DESCRIPTION
On a call with David Murray the other day, David revealed that the open bus reads on Proto 4 boards always returned `$C0`. This seems like a reasonable behavior to emulate, while changing how reads and writes happen to RAM banks beyond what is configured in the emulator.

Prior behavior was to wrap the bank number, in effect forcing the upper address lines low. New behavior is to ignore writes and to read open bus.

Also fixed the address wrap in the disassembler part of the debugger - no longer advances from $FFFF to $10000, but rather to $0000.

Closes #15 