### PR TITLE
Improve command key documentation for MacOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,14 +175,21 @@ The following keys can be used for controlling games:
 Functions while running
 -----------------------
 
+#### Windows and Linux
 * `Ctrl` + `F` and `Ctrl` + `Return` will toggle full screen mode.
 * `Ctrl` + `M` will toggle mouse capture mode.
 * `Ctrl` + `R` will reset the computer.
-* `Ctrl` + `S` will save a system dump (configurable with `-dump`) to disk.
+* `Ctrl` + `S` will save a system dump configurable with `-dump`) to disk.
 * `Ctrl` + `V` will paste the clipboard by injecting key presses.
 * `Ctrl` + `=` and `Ctrl` + `+` will toggle warp mode.
 
-On the Mac, use the `⌘` key instead.
+#### Mac OS
+* `⌘F` and `⌘Return` will toggle full screen mode.
+* `⇧⌘M` will toggle mouse capture mode.
+* `⌘R` will reset the computer.
+* `⌘S` will save a system dump (configurable with `-dump`) to disk.
+* `⌘V` will paste the clipboard by injecting key presses.
+* `⌘=` and `⇧⌘+` will toggle warp mode.
 
 
 GIF Recording

--- a/src/glue.h
+++ b/src/glue.h
@@ -27,7 +27,7 @@
 #define WINDOW_TITLE "Commander X16"
 
 #ifdef __APPLE__
-#define MOUSE_GRAB_MSG " (\xE2\x8C\x98+M to release mouse)"
+#define MOUSE_GRAB_MSG " (\xE2\x87\xA7\xE2\x8C\x98M to release mouse)"
 #else
 #define MOUSE_GRAB_MSG " (Ctrl+M to release mouse)"
 #endif


### PR DESCRIPTION
particularly for mouse capture, which additionally needs shift to avoid the event being captured by the OS