### PR TITLE
Minor fixes to wasm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ endif
 ifdef EMSCRIPTEN
 	LDFLAGS+=--shell-file webassembly/x16emu-template.html --preload-file rom.bin -s TOTAL_MEMORY=32MB -s ASSERTIONS=1 -s DISABLE_DEPRECATED_FIND_EVENT_TARGET_BEHAVIOR=1
 	# To the Javascript runtime exported functions
-	LDFLAGS+=-s EXPORTED_FUNCTIONS='["_j2c_reset", "_j2c_paste", "_j2c_start_audio", _main]' -s EXTRA_EXPORTED_RUNTIME_METHODS='["ccall", "cwrap"]' -s USE_ZLIB=1
+	LDFLAGS+=-s EXPORTED_FUNCTIONS='["_j2c_reset", "_j2c_paste", "_j2c_start_audio", _main]' -s EXTRA_EXPORTED_RUNTIME_METHODS='["ccall", "cwrap"]' -s USE_ZLIB=1 -s EXIT_RUNTIME=1
 	CFLAGS+=-s USE_ZLIB=1
 	X16_OUTPUT=x16emu.html
 	MAKECART_OUTPUT=makecart.html

--- a/src/main.c
+++ b/src/main.c
@@ -999,6 +999,9 @@ main(int argc, char **argv)
 	// Available since SDL 2.0.8
 	SDL_SetHint(SDL_HINT_VIDEO_X11_NET_WM_BYPASS_COMPOSITOR, "0");
 #endif
+#ifdef __EMSCRIPTEN__
+	emscripten_set_main_loop(emscripten_main_loop, 0, 0);
+#endif
 	if (!headless) {
 		SDL_Init(SDL_INIT_VIDEO | SDL_INIT_EVENTS | SDL_INIT_GAMECONTROLLER | SDL_INIT_AUDIO);
 		audio_init(audio_dev_name, audio_buffers);
@@ -1020,6 +1023,7 @@ main(int argc, char **argv)
 	instruction_counter = 0;
 
 #ifdef __EMSCRIPTEN__
+	emscripten_cancel_main_loop();
 	emscripten_set_main_loop(emscripten_main_loop, 0, 1);
 #else
 	emulator_loop(NULL);

--- a/src/smc.c
+++ b/src/smc.c
@@ -10,6 +10,9 @@
 #include "smc.h"
 #include "glue.h"
 #include "i2c.h"
+#ifdef __EMSCRIPTEN__
+#include <emscripten.h>
+#endif
 
 // 0x01 0x00      - Power Off
 // 0x01 0x01      - Hard Reboot
@@ -56,6 +59,9 @@ smc_write(uint8_t a, uint8_t v) {
 		case 1:
 			if (v == 0) {
 				printf("SMC Power Off.\n");
+#ifdef __EMSCRIPTEN__
+				emscripten_force_exit(0);
+#endif
 				exit(0);
 			} else if (v == 1) {
 				machine_reset();

--- a/src/video.c
+++ b/src/video.c
@@ -205,7 +205,7 @@ video_init(int window_scale, float screen_x_scale, char *quality)
 									SDL_TEXTUREACCESS_STREAMING,
 									SCREEN_WIDTH, SCREEN_HEIGHT);
 
-	SDL_SetWindowTitle(window, "Commander X16");
+	SDL_SetWindowTitle(window, WINDOW_TITLE);
 	SDL_SetWindowIcon(window, CommanderX16Icon());
 
 	SDL_ShowCursor(SDL_DISABLE);


### PR DESCRIPTION
Under EMSCRIPTEN, instantiating a sort of dummy main loop before creating the window suppresses a console error: `emscripten_set_main_loop_timing: Cannot set timing mode for main loop since a main loop does not exist! Call emscripten_set_main_loop first to set one up.`

The SDL window creation seems to result in an implicit call to `emscripten_set_main_loop_timing()`.

We don't give the system a chance to run the main loop as declared in the first instance of `emscripten_set_main_loop()` because the final argument, "simulate infinite loop", is false. Therefore, the change is effective at suppressing the error.

Other fixes: 
- POWEROFF in BASIC no longer causes the wasm console to spin out of control
- use constant for first setting of window title (unrelated to wasm changes)