### PR TITLE
hostfs cbdos_flags fails on emu reset due to the selected ROM bank being 4

### DIFF
--- a/src/ieee.c
+++ b/src/ieee.c
@@ -1322,17 +1322,17 @@ ieee_init()
 	// Locate and remember cbdos_flags variable address in KERNAL vars
 	{
 		// check JMP instruction at ACPTR API
-		if (read6502(0xffa5) != 0x4c) goto fail;
+		if (real_read6502(0xffa5, true, 0) != 0x4c) goto fail;
 
 		// get address of ACPTR routine
-		uint16_t kacptr = read6502(0xffa6) | read6502(0xffa7) << 8;
+		uint16_t kacptr = real_read6502(0xffa6, true, 0) | real_read6502(0xffa7, true, 0) << 8;
 		if (kacptr < 0xc000) goto fail;
 
 		// first instruction is BIT cbdos_flags
-		if (read6502(kacptr) != 0x2c) goto fail;
+		if (real_read6502(kacptr, true, 0) != 0x2c) goto fail;
 
 		// get the address of cbdos_flags
-		cbdos_flags = read6502(kacptr+1) | read6502(kacptr+2) << 8;
+		cbdos_flags = real_read6502(kacptr+1, true, 0) | real_read6502(kacptr+2, true, 0) << 8;
 
 		if (cbdos_flags < 0x0200 || cbdos_flags >= 0x0400) goto fail;
 		goto success;


### PR DESCRIPTION
This change always retrieves the ROM values from bank 0