### PR TITLE
fix off by one error in row calculation

### DIFF
--- a/src/video.c
+++ b/src/video.c
@@ -870,13 +870,13 @@ render_line(uint16_t y, float scan_pos_x)
 		if ((dc_video & 3) > 1) { // interlaced mode
 			if ((y >> 1) == 0) {
 				eff_y_fp = y*(prev_reg_composer[1][2] << 9);
-			} else if (y >= vstart) {
+			} else if (y > vstart) {
 				eff_y_fp += (prev_reg_composer[1][2] << 10);
 			}
 		} else {
 			if (y == 0) {
 				eff_y_fp = 0;
-			} else if (y >= vstart) {
+			} else if (y > vstart) {
 				eff_y_fp += (prev_reg_composer[1][2] << 9);
 			}
 		}


### PR DESCRIPTION
If y == vstart, then that's equivalent to being our effective zero line, so we should not increment yet.  The increment should happen on lines that follow.