### PR TITLE
Make ROM/RAM bank I/O works like hardware

### DIFF
--- a/src/cpu/fake6502.c
+++ b/src/cpu/fake6502.c
@@ -144,6 +144,7 @@ uint8_t waiting = 0;
 extern uint8_t read6502(uint16_t address);
 extern void write6502(uint16_t address, uint8_t value);
 extern void stop6502(uint16_t address);
+extern void vp6502();
 
 #include "support.h"
 #include "modes.h"
@@ -174,6 +175,7 @@ void nmi6502() {
     push8(status & ~FLAG_BREAK);
     setinterrupt();
     cleardecimal();
+    vp6502();
     pc = (uint16_t)read6502(0xFFFA) | ((uint16_t)read6502(0xFFFB) << 8);
     clockticks6502 += 7; // consumed by CPU to process interrupt
     waiting = 0;
@@ -185,6 +187,7 @@ void irq6502() {
         push8(status & ~FLAG_BREAK);
         setinterrupt();
         cleardecimal();
+        vp6502();
         pc = (uint16_t)read6502(0xFFFE) | ((uint16_t)read6502(0xFFFF) << 8);
         clockticks6502 += 7; // consumed by CPU to process interrupt
     }

--- a/src/main.c
+++ b/src/main.c
@@ -1415,6 +1415,7 @@ emulator_loop(void *param)
 
 		if (video_get_irq_out() || via1_irq() || (has_via2 && via2_irq())) {
 //			printf("IRQ!\n");
+			memory_set_rom_bank(0);
 			irq6502();
 		}
 

--- a/src/main.c
+++ b/src/main.c
@@ -1465,7 +1465,6 @@ emulator_loop(void *param)
 
 		if (video_get_irq_out() || via1_irq() || (has_via2 && via2_irq())) {
 //			printf("IRQ!\n");
-			memory_set_rom_bank(0);
 			irq6502();
 		}
 

--- a/src/memory.c
+++ b/src/memory.c
@@ -240,6 +240,12 @@ write6502(uint16_t address, uint8_t value)
 	}
 }
 
+void
+vp6502()
+{
+	memory_set_rom_bank(0);
+}
+
 //
 // saves the memory content into a file
 //

--- a/src/memory.c
+++ b/src/memory.c
@@ -32,7 +32,6 @@ bool *RAM_access_flags;
 
 #define DEVICE_EMULATOR (0x9fb0)
 
-uint8_t cpuio_read(uint8_t reg);
 void cpuio_write(uint8_t reg, uint8_t value);
 
 void
@@ -135,9 +134,7 @@ read6502(uint16_t address) {
 uint8_t
 real_read6502(uint16_t address, bool debugOn, uint8_t bank)
 {
-	if (address < 2) { // CPU I/O ports
-		return cpuio_read(address);
-	} else if (address < 0x9f00) { // RAM
+	if (address < 0x9f00) { // RAM
 		return RAM[address];
 	} else if (address < 0xa000) { // I/O
 		if (!debugOn && address >= 0x9fa0) {
@@ -197,11 +194,12 @@ write6502(uint16_t address, uint8_t value)
 				RAM_access_flags[0xa000 + (effective_ram_bank() << 13) + address - 0xa000] = true;
 		}
 	}
-
-	// Write to memory
-	if (address < 2) { // CPU I/O ports
+	// Write to CPU I/O ports
+	if (address < 2) { 
 		cpuio_write(address, value);
-	} else if (address < 0x9f00) { // RAM
+	}
+	// Write to memory
+	if (address < 0x9f00) { // RAM
 		RAM[address] = value;
 	} else if (address < 0xa000) { // I/O
 		if (address >= 0x9fa0) {
@@ -284,18 +282,6 @@ uint8_t
 memory_get_rom_bank()
 {
 	return rom_bank;
-}
-
-uint8_t
-cpuio_read(uint8_t reg)
-{
-	switch (reg) {
-		case 0:
-			return memory_get_ram_bank();
-		case 1:
-			return memory_get_rom_bank();
-	}
-	return 0; // to make the compiler happy
 }
 
 void

--- a/src/memory.h
+++ b/src/memory.h
@@ -13,6 +13,7 @@
 uint8_t read6502(uint16_t address);
 uint8_t real_read6502(uint16_t address, bool debugOn, uint8_t bank);
 void write6502(uint16_t address, uint8_t value);
+void vp6502();
 
 void memory_init();
 void memory_reset();


### PR DESCRIPTION
Reads should return values from shadowed RAM writes, not bank registers