### PR TITLE
Escape key is escape instead of STOP.  STOP is still possible with Ctrl+C

### DIFF
--- a/src/keyboard.c
+++ b/src/keyboard.c
@@ -6,7 +6,7 @@
 #include "keyboard.h"
 
 #define EXTENDED_FLAG 0x100
-#define ESC_IS_BREAK /* if enabled, Esc sends Break/Pause key instead of Esc */
+// #define ESC_IS_BREAK /* if enabled, Esc sends Break/Pause key instead of Esc */
 
 int
 ps2_scancode_from_SDL_Scancode(SDL_Scancode scancode)


### PR DESCRIPTION
This seems overdue, and there's strong consensus for this change in the Discord.