### PR TITLE
Hide host mouse cursor only when 1) the kernal mouse is enabled or 2) mouse is grabbed by emulator

### DIFF
--- a/src/glue.h
+++ b/src/glue.h
@@ -94,5 +94,6 @@ extern bool nvram_dirty;
 extern uint8_t nvram[0x40];
 
 extern bool mouse_grabbed;
+extern bool kernal_mouse_enabled;
 extern char window_title[];
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -265,6 +265,12 @@ machine_dump(const char* reason)
 	printf("Dumped system to %s.\n", filename);
 }
 
+void mouse_state_init(void)
+{
+	kernal_mouse_enabled = 0;
+	SDL_ShowCursor((mouse_grabbed || kernal_mouse_enabled) ? SDL_DISABLE : SDL_ENABLE);
+}
+
 void
 machine_reset()
 {
@@ -276,6 +282,7 @@ machine_reset()
 		via2_init();
 	}
 	video_reset();
+	mouse_state_init();
 	reset6502();
 }
 
@@ -1427,7 +1434,7 @@ emulator_loop(void *param)
 
 		// Change this comparison value if ever additional KERNAL
 		// API calls are snooped in this routine.
-		
+
 		if (pc >= 0xff68 && is_kernal()) {
 			if (pc == 0xff68) {
 				kernal_mouse_enabled = !!a;

--- a/src/main.c
+++ b/src/main.c
@@ -1425,7 +1425,10 @@ emulator_loop(void *param)
 			break;
 		}
 
-		if (is_kernal() && pc >= 0xff68) {
+		// Change this comparison value if ever additional KERNAL
+		// API calls are snooped in this routine.
+		
+		if (pc >= 0xff68 && is_kernal()) {
 			if (pc == 0xff68) {
 				kernal_mouse_enabled = !!a;
 				SDL_ShowCursor((mouse_grabbed || kernal_mouse_enabled) ? SDL_DISABLE : SDL_ENABLE);

--- a/src/video.c
+++ b/src/video.c
@@ -76,6 +76,7 @@ static SDL_Renderer *renderer;
 static SDL_Texture *sdlTexture;
 static bool is_fullscreen = false;
 bool mouse_grabbed = false;
+bool kernal_mouse_enabled = false;
 
 static uint8_t video_ram[0x20000];
 static uint8_t palette[256 * 2];
@@ -207,8 +208,6 @@ video_init(int window_scale, float screen_x_scale, char *quality)
 
 	SDL_SetWindowTitle(window, WINDOW_TITLE);
 	SDL_SetWindowIcon(window, CommanderX16Icon());
-
-	SDL_ShowCursor(SDL_DISABLE);
 
 	if (record_gif != RECORD_GIF_DISABLED) {
 		if (!strcmp(gif_path+strlen(gif_path)-5, ",wait")) {
@@ -406,6 +405,7 @@ void
 mousegrab_toggle() {
 	mouse_grabbed = !mouse_grabbed;
 	SDL_SetRelativeMouseMode(mouse_grabbed);
+	SDL_ShowCursor((mouse_grabbed || kernal_mouse_enabled) ? SDL_DISABLE : SDL_ENABLE);
 	sprintf(window_title, WINDOW_TITLE "%s", mouse_grabbed ? MOUSE_GRAB_MSG : "");
 	video_update_title(window_title);
 }


### PR DESCRIPTION
This should improve mouse integration and fewer instances of frustrated users "losing" the host cursor over the emulator window.

This change rearranges the snooped API calls so that there are potentially fewer checks in the hot path.