### PR TITLE
Process multiple SDL events per frame

### DIFF
--- a/src/video.c
+++ b/src/video.c
@@ -1243,14 +1243,14 @@ video_update()
 				}
 				handle_keyboard(true, event.key.keysym.sym, event.key.keysym.scancode);
 			}
-			return true;
+			continue;
 		}
 		if (event.type == SDL_KEYUP) {
 			if (event.key.keysym.scancode == LSHORTCUT_KEY || event.key.keysym.scancode == RSHORTCUT_KEY) {
 				cmd_down = false;
 			}
 			handle_keyboard(false, event.key.keysym.sym, event.key.keysym.scancode);
-			return true;
+			continue;
 		}
 		if (event.type == SDL_MOUSEBUTTONDOWN) {
 			switch (event.button.button) {


### PR DESCRIPTION
The SDL event-processing loop that is called once per frame only processes one pending event if it's a keydown or keyup.  This gets in the way of other events that might be pending and delays them until the next frame.

This event loop still sends all key events into the emulated SMC's queue, so we're still behaving like hardware and the ROM only fetches one keycode per kernal interrupt handler call by default, even after this change.

Closes #69 