### PR TITLE
MACPTR on closed file/EOF should always return zero bytes

### DIFF
--- a/src/ieee.c
+++ b/src/ieee.c
@@ -1580,6 +1580,8 @@ MACPTR(uint16_t addr, uint16_t *c, uint8_t stream_mode)
 				break;
 			}
 		} while(i < count);
+	} else {
+		ret = 0x42;
 	}
 	*c = i;
 	return ret;


### PR DESCRIPTION
Before this change, hostsfs MACPTR would still return a single byte even on a closed file, as if they called ACPTR.  MACPTR is special and shouldn't simply respond like ACPTR.