### PR TITLE
add -mhz command line option, correct open bus read behavior

### DIFF
--- a/src/glue.h
+++ b/src/glue.h
@@ -12,8 +12,6 @@
 //#define TRACE
 //#define PERFSTAT
 
-#define MHZ 8
-
 #define NUM_MAX_RAM_BANKS 256
 #define NUM_ROM_BANKS 32
 #define NUM_CART_BANKS (256 - 32)
@@ -21,8 +19,6 @@
 #define RAM_SIZE (0xa000 + num_ram_banks * 8192) /* $0000-$9FFF + banks at $A000-$BFFF */
 #define ROM_SIZE (NUM_ROM_BANKS * 16384)   /* banks at $C000-$FFFF */
 #define CART_SIZE (NUM_CART_BANKS * 16384)  /* expansion banks at $C000-$FFFF */
-
-#define OPEN_BUS_READ 0xC0 // Proto 4 open data bus read behavior, according to David Murray
 
 #define WINDOW_TITLE "Commander X16"
 
@@ -92,6 +88,8 @@ extern bool video_is_special_address(int addr);
 extern uint8_t activity_led;
 extern bool nvram_dirty;
 extern uint8_t nvram[0x40];
+
+extern uint8_t MHZ;
 
 extern bool mouse_grabbed;
 extern bool kernal_mouse_enabled;

--- a/src/main.c
+++ b/src/main.c
@@ -969,7 +969,7 @@ main(int argc, char **argv)
 			if (!argc || argv[0][0] == '-') {
 				usage();
 			}
-			MHZ = (int)strtol(argv[0], NULL, 10);
+			MHZ = (uint8_t)strtol(argv[0], NULL, 10);
 			if (MHZ < 1 || MHZ > 40) {
 				usage();
 			}

--- a/src/main.c
+++ b/src/main.c
@@ -121,6 +121,8 @@ bool test_init_complete=false;
 bool headless = false;
 bool testbench = false;
 
+uint8_t MHZ = 8;
+
 #ifdef TRACE
 bool trace_mode = false;
 uint16_t trace_address = 0;
@@ -514,6 +516,11 @@ usage()
 	printf("\tInstall the second VIA chip expansion at $9F10\n");
 	printf("-testbench\n");
 	printf("\tHeadless mode for unit testing with an external test runner\n");
+	printf("-mhz <integer>\n");
+	printf("\tRun the emulator with a system clock speed other than the default of\n");
+	printf("\t8 MHz. Valid values are in the range of 1-40, inclusive. This option\n");
+	printf("\tis meant mainly for benchmarking, and may not reflect accurate\n");
+	printf("\thardware behavior.\n");
 #ifdef TRACE
 	printf("-trace [<address>]\n");
 	printf("\tPrint instruction trace. Optionally, a trigger address\n");
@@ -956,6 +963,18 @@ main(int argc, char **argv)
 			argv++;
 			testbench=true;
 			headless=true;
+		} else if (!strcmp(argv[0], "-mhz")){
+			argc--;
+			argv++;
+			if (!argc || argv[0][0] == '-') {
+				usage();
+			}
+			MHZ = (int)strtol(argv[0], NULL, 10);
+			if (MHZ < 1 || MHZ > 40) {
+				usage();
+			}
+			argc--;
+			argv++;
 		} else {
 			usage();
 		}

--- a/src/memory.c
+++ b/src/memory.c
@@ -168,7 +168,7 @@ real_read6502(uint16_t address, bool debugOn, uint8_t bank)
 		if (ramBank < num_ram_banks) {
 			return RAM[0xa000 + (ramBank << 13) + address - 0xa000];
 		} else {
-			return OPEN_BUS_READ;
+			return (address >> 8) & 0xff; // open bus read
 		}
 
 
@@ -178,7 +178,7 @@ real_read6502(uint16_t address, bool debugOn, uint8_t bank)
 			return ROM[(romBank << 14) + address - 0xc000];
 		} else {
 			if (!CART) {
-				return OPEN_BUS_READ;
+				return (address >> 8) & 0xff; // open bus read
 			}
 			return cartridge_read(address, romBank);
 		}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/395186/228746448-52fb8233-a1a8-454b-818e-13e571e96d94.png)

For the open bus reads, rather than `$C0` as David originally suspected, it's actually the high byte of the target address, most likely floating from the instruction fetch from the last clock.  This change reflects that behavior in the emu.