### PR TITLE
Prevent audio buffer overflow + Fix audio resampling

### DIFF
--- a/src/audio.c
+++ b/src/audio.c
@@ -296,8 +296,8 @@ audio_render()
 			vera_out_r = ((psg_buf[pos + 1] + pcm_buf[pos + 1]) >> 8) * 32768;
 		} else {
 			filter_idx = (vera_samp_pos_rd >> (SAMP_POS_FRAC_BITS - 8)) & 0xff;
+			pos = (vera_samp_pos_rd >> SAMP_POS_FRAC_BITS) * 2;
 			for (int j = 0; j < 8; j += 2) {
-				pos = (vera_samp_pos_rd >> SAMP_POS_FRAC_BITS) * 2;
 				samp[j] = (psg_buf[pos] + pcm_buf[pos]) >> 8;
 				samp[j + 1] = (psg_buf[pos + 1] + pcm_buf[pos + 1]) >> 8;
 				pos = (pos + 2) & (SAMP_POS_MASK * 2);
@@ -312,8 +312,8 @@ audio_render()
 			vera_out_r += samp[7] * filter[511 - filter_idx];
 		}
 		filter_idx = (ym_samp_pos_rd >> (SAMP_POS_FRAC_BITS - 8)) & 0xff;
+		pos = (ym_samp_pos_rd >> SAMP_POS_FRAC_BITS) * 2;
 		for (int j = 0; j < 8; j += 2) {
-			pos = (ym_samp_pos_rd >> SAMP_POS_FRAC_BITS) * 2;
 			samp[j] = ym_buf[pos];
 			samp[j + 1] = ym_buf[pos + 1];
 			pos = (pos + 2) & (SAMP_POS_MASK * 2);

--- a/src/audio.c
+++ b/src/audio.c
@@ -68,6 +68,7 @@ static int16_t * buffer;
 static uint32_t buffer_size = 0;
 static uint32_t rdidx = 0;
 static uint32_t wridx = 0;
+static uint32_t buffer_written = 0;
 static uint32_t vera_samp_pos_rd = 0;
 static uint32_t vera_samp_pos_wr = 0;
 static uint32_t vera_samp_pos_hd = 0;
@@ -105,6 +106,7 @@ audio_callback(void *userdata, Uint8 *stream, int len)
 			spos += actual_len * SAMPLE_BYTES;
 			len -= actual_len * SAMPLE_BYTES;
 			rdidx = (rdidx + actual_len * 2) % buffer_size;
+			buffer_written -= actual_len * 2;
 		}
 	}
 	uint32_t actual_len = SDL_min(len / SAMPLE_BYTES, (wridx - rdidx) / 2);
@@ -113,6 +115,7 @@ audio_callback(void *userdata, Uint8 *stream, int len)
 		spos += actual_len * SAMPLE_BYTES;
 		len -= actual_len * SAMPLE_BYTES;
 		rdidx = (rdidx + actual_len * 2) % buffer_size;
+		buffer_written -= actual_len * 2;
 	}
 	if (len > 0) memset(&stream[spos], 0, len);
 }
@@ -144,6 +147,7 @@ audio_init(const char *dev_name, int num_audio_buffers)
 	buffer = malloc(buffer_size * sizeof(int16_t));
 	rdidx = 0;
 	wridx = 0;
+	buffer_written = 0;
 
 	SDL_AudioSpec desired;
 	SDL_AudioSpec obtained;
@@ -345,6 +349,13 @@ audio_render()
 	}
 	if ((wridx - wridx_old) > 0) {
 		wav_recorder_process(&buffer[wridx_old], (wridx - wridx_old) / 2);
+	}
+	buffer_written += len * 2;
+	if (buffer_written > buffer_size) {
+		// Prevent the buffer from overflowing by skipping the read pointer ahead.
+		uint32_t buffer_skip_amount = (buffer_written / buffer_size) * SAMPLES_PER_BUFFER * 2;
+		rdidx = (rdidx + buffer_skip_amount) % buffer_size;
+		buffer_written -= buffer_skip_amount;
 	}
 	SDL_UnlockAudioDevice(audio_dev);
 


### PR DESCRIPTION
This PR contains two changes:
1) Prevent the audio buffer from overflowing.
When the emulator generates more samples than will fit in the audio buffer (e.g., during warp mode and during large catch-ups), the write pointer would overtake the read pointer, and the emulator would see it as the buffer suddenly becoming empty again, which could cause audio stuttering.
The changed behavior is, when the audio buffer overflows, the read pointer is skipped forward by the length of one or more "-abufs" setting to clear enough room in the buffer to un-overflow it.

2) Fix an issue with the audio resampling logic which degraded audio.
Previously, the resampling logic for both the VERA and YM chip had a misplaced line of code, which caused the resampling to not work as intended, and made the YM audio in particular sound degraded. This is now corrected and the audio sounds more like it should.