### PR TITLE
Off by one error, write outside allocated space

### DIFF
--- a/src/ieee.c
+++ b/src/ieee.c
@@ -161,7 +161,7 @@ parse_dos_filename(const char *name)
 	char *newname = malloc(strlen(name)+1);
 	int i, j;
 
-	newname[strlen(name)+1] = 0;
+	newname[strlen(name)] = 0;
 	
 	overwrite = false;
 


### PR DESCRIPTION
Running x16emu under valgrind finally helped me find this, once the notion finally penetrated my thick skull that `x = malloc(n)`  doesn't mean you can assign a value to `x[n]`.

This is the most likely candidate yet for #50 and #42 and likely the cause of David's inconsistent crashes.