### PR TITLE
[VIDEO] new command line option -midline-effects allows midline VERA …

### DIFF
--- a/src/glue.h
+++ b/src/glue.h
@@ -74,6 +74,7 @@ extern bool warp_mode;
 extern bool testbench;
 extern bool has_via2;
 extern uint32_t host_sample_rate;
+extern bool enable_midline;
 
 extern void machine_dump(const char* reason);
 extern void machine_reset();

--- a/src/main.c
+++ b/src/main.c
@@ -120,6 +120,7 @@ char *scale_quality = "best";
 bool test_init_complete=false;
 bool headless = false;
 bool testbench = false;
+bool enable_midline = false;
 
 uint8_t MHZ = 8;
 
@@ -529,6 +530,9 @@ usage()
 	printf("\t8 MHz. Valid values are in the range of 1-40, inclusive. This option\n");
 	printf("\tis meant mainly for benchmarking, and may not reflect accurate\n");
 	printf("\thardware behavior.\n");
+	printf("-midline-effects\n");
+	printf("\tApproximate mid-line raster effects when changing tile, sprite,\n");
+	printf("\tand palette data. Requires a fast host CPU.\n");
 #ifdef TRACE
 	printf("-trace [<address>]\n");
 	printf("\tPrint instruction trace. Optionally, a trigger address\n");
@@ -983,6 +987,10 @@ main(int argc, char **argv)
 			}
 			argc--;
 			argv++;
+		} else if (!strcmp(argv[0], "-midline-effects")){
+			argc--;
+			argv++;
+			enable_midline = true;
 		} else {
 			usage();
 		}

--- a/src/video.c
+++ b/src/video.c
@@ -1490,7 +1490,8 @@ void video_write(uint8_t reg, uint8_t value) {
 			break;
 		case 0x03:
 		case 0x04: {
-			video_step(MHZ, 0, true); // potential midline raster effect
+			if (enable_midline)
+				video_step(MHZ, 0, true); // potential midline raster effect
 			uint32_t address = get_and_inc_address(reg - 3);
 			if (log_video) {
 				printf("WRITE video_space[$%X] = $%02X\n", address, value);


### PR DESCRIPTION
…data port writes to force partial line renders. Now disabled by default due to excess CPU burden.