### PR TITLE
[BUILD] allow building with link time code generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,12 @@ endif
 CFLAGS=-std=c99 -O3 -Wall -Werror -g $(shell $(SDL2CONFIG) --cflags) -Isrc/extern/include -Isrc/extern/src
 LDFLAGS=$(shell $(SDL2CONFIG) --libs) -lm -lz
 
+# build with link time optimization
+ifdef LTO
+	CFLAGS+=-flto
+	LDFLAGS+=-flto
+endif
+
 X16_ODIR = build/x16emu
 X16_SDIR = src
 


### PR DESCRIPTION
Setting LTO in the environment lets the compiler use link time code generation. Seems to pretty consistently generate a smaller and faster binary on both linux and mac environments. May hurt debuggability, so probably makes sense to make it optional.

Probably worth setting for official builds too, since it's a freebie optimization.