### PR TITLE
HostFS: fix additional behaviors which did not match native DOS/SD card behaviors

### DIFF
--- a/src/ieee.c
+++ b/src/ieee.c
@@ -1603,7 +1603,7 @@ MACPTR(uint16_t addr, uint16_t *c, uint8_t stream_mode)
 			}
 		} while(i < count);
 	} else {
-		ret = 0x42;
+		ret = -2;
 	}
 	*c = i;
 	return ret;

--- a/src/main.c
+++ b/src/main.c
@@ -1223,9 +1223,13 @@ handle_ieee_intercept()
 		case 0xFF44: {
 			uint16_t count = a;
 			s=MACPTR(y << 8 | x, &count, status & 0x01);
-			x = count & 0xff;
-			y = count >> 8;
-			status &= 0xfe; // clear C -> supported
+			if (s == -2) {
+				status = (status | 1); // SEC (unsupported, or in this case, no open context)
+			} else {
+				x = count & 0xff;
+				y = count >> 8;
+				status &= 0xfe; // clear C -> supported
+			}
 			break;
 		}
 		case 0xFF93:

--- a/src/main.c
+++ b/src/main.c
@@ -1249,6 +1249,7 @@ handle_ieee_intercept()
 			s=UNLSN();
 			if (s == -2) { // special error behavior
 				status = (status | 1); // SEC
+				s = 0x42;
 			} else {
 				status = (status & ~1); // CLC
 			}


### PR DESCRIPTION
The symptom was failed headerless loads wouldn't set carry, but regular headered loads would.  The reason was that headerless loads try to read the first byte of the file with MACPTR, which had incorrect behavior on a closed file with respect to the carry flag.  Regular loads would call ACPTR for the first two bytes, which did result in the desired behavior.

* LOAD "X",8,1
  * Read low byte of load address  <-- would fail here correctly on missing file, with the routine setting carry
  * Read high byte of load address
  * MACPTR in the rest
  
* BLOAD "X",8,1,$A000
  * MACPTR <--  previously wouldn't set carry on failure.  (The only reasons for setting carry are unsupported device, and, previously overlooked by me, no file open for this channel)

Also, UNLSN wasn't setting status properly on FNF, but I don't think this affects KERNAL behaviors for LOAD.  In fact LOAD and SAVE ignore the carry flag and status upon UNLSN.  This may be a remnant of the C64 behavior which is to accumulate errors in STATUS. The X16 behavior for ACPTR is to clear status on successful retrieval.

Closes #108 