### PR TITLE
Support for NumLock key + menu key

### DIFF
--- a/src/keyboard.c
+++ b/src/keyboard.c
@@ -189,7 +189,7 @@ keynum_from_SDL_Scancode(SDL_Scancode scancode)
 		case SDL_SCANCODE_RGUI:
 			return 63;
 		case SDL_SCANCODE_APPLICATION: // Menu
-			return 0;
+			return 65;
 		case SDL_SCANCODE_NONUSBACKSLASH:
 			return 45;
 		case SDL_SCANCODE_KP_ENTER:

--- a/src/keyboard.c
+++ b/src/keyboard.c
@@ -224,6 +224,8 @@ keynum_from_SDL_Scancode(SDL_Scancode scancode)
 			return 100;
 		case SDL_SCANCODE_KP_DIVIDE:
 			return 95;
+		case SDL_SCANCODE_NUMLOCKCLEAR:
+			return 90;
 		default:
 			return 0;
 	}
@@ -232,13 +234,15 @@ keynum_from_SDL_Scancode(SDL_Scancode scancode)
 void
 handle_keyboard(bool down, SDL_Keycode sym, SDL_Scancode scancode)
 {
+	int keynum = keynum_from_SDL_Scancode(scancode);
+	
+	if (keynum == 0) return;
+
 	if (down) {
 		if (log_keyboard) {
 			printf("DOWN 0x%02X\n", scancode);
 			fflush(stdout);
 		}
-
-		int keynum = keynum_from_SDL_Scancode(scancode);
 
 		if (keynum & EXTENDED_FLAG) {
 			i2c_kbd_buffer_add(0x7f);
@@ -250,11 +254,10 @@ handle_keyboard(bool down, SDL_Keycode sym, SDL_Scancode scancode)
 			fflush(stdout);
 		}
 
-		int keynum = keynum_from_SDL_Scancode(scancode) | 0b10000000;
+		keynum = keynum | 0b10000000;
 		if (keynum & EXTENDED_FLAG) {
 			i2c_kbd_buffer_add(0xff);
 		}
 		i2c_kbd_buffer_add(keynum & 0xff);
 	}
 }
-


### PR DESCRIPTION
Adds support for the NumLock key.

Currently when an unsupported key is released, the emulator will put 0x80 in the keyboard buffer, which is not correct behavior.

Note that I don't have a keyboard with the NumLock key, so I haven't actually been able to test that part.