### PR TITLE
cleanup nicely at poweroff, fixes sticky fullscreen screenmode issue.

### DIFF
--- a/src/glue.h
+++ b/src/glue.h
@@ -81,6 +81,7 @@ extern void machine_reset();
 extern void machine_paste(char *text);
 extern void machine_toggle_warp();
 extern void init_audio();
+extern void main_shutdown();
 
 extern bool video_is_tilemap_address(int addr);
 extern bool video_is_tiledata_address(int addr);

--- a/src/main.c
+++ b/src/main.c
@@ -121,6 +121,7 @@ bool test_init_complete=false;
 bool headless = false;
 bool testbench = false;
 bool enable_midline = false;
+char *cartridge_path = NULL;
 
 uint8_t MHZ = 8;
 
@@ -564,7 +565,6 @@ main(int argc, char **argv)
 	char *prg_path = NULL;
 	char *bas_path = NULL;
 	char *sdcard_path = NULL;
-	char *cartridge_path = NULL;
 	bool run_geos = false;
 	bool run_test = false;
 	int test_number = 0;
@@ -1098,6 +1098,11 @@ main(int argc, char **argv)
 	emulator_loop(NULL);
 #endif
 
+	main_shutdown();
+	return 0;
+}
+
+void main_shutdown() {
 	if (!headless){
 		wav_recorder_shutdown();
 		audio_close();
@@ -1136,7 +1141,6 @@ main(int argc, char **argv)
 	}
 #endif
 
-	return 0;
 }
 
 bool

--- a/src/smc.c
+++ b/src/smc.c
@@ -59,6 +59,7 @@ smc_write(uint8_t a, uint8_t v) {
 		case 1:
 			if (v == 0) {
 				printf("SMC Power Off.\n");
+				main_shutdown();
 #ifdef __EMSCRIPTEN__
 				emscripten_force_exit(0);
 #endif

--- a/src/video.c
+++ b/src/video.c
@@ -1325,6 +1325,8 @@ video_end()
 		record_gif = RECORD_GIF_DISABLED;
 	}
 
+	is_fullscreen = false;
+	SDL_SetWindowFullscreen(window, 0);
 	SDL_DestroyRenderer(renderer);
 	SDL_DestroyWindow(window);
 }


### PR DESCRIPTION
Problem scenario was before (Linux):

- start emulator
- ctrl+f to go fullscreen
- type 'poweroff' 
- emulator quits but desktop screen mode remains in 640x480

this PR makes sure that:
- video shutdown resets the full screen mode
- smc shutdown properly calls the shutdown machinery instead of jumping to exit() immediately