### PR TITLE
Enable emulator window transparency

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -116,6 +116,7 @@ char *startin_path = NULL;
 uint8_t keymap = 0; // KERNAL's default
 int window_scale = 1;
 float screen_x_scale = 1.0;
+float window_opacity = 1.0;
 char *scale_quality = "best";
 bool test_init_complete=false;
 bool headless = false;
@@ -497,6 +498,8 @@ usage()
 	printf("\tStretch output to 16:9 resolution to mimic display of a widescreen monitor.\n");
 	printf("-fullscreen\n");
 	printf("\tStart up in fullscreen mode instead of in a window.\n");
+	printf("-opacity (0.0,...,1.0)\n");
+	printf("\tSet the opacity value (0.0 for transparent, 1.0 for opaque) of the window. (default: %.1f)\n", window_opacity);
 	printf("-debug [<address>]\n");
 	printf("\tEnable debugger. Optionally, set a breakpoint\n");
 	printf("-randram\n");
@@ -909,6 +912,15 @@ main(int argc, char **argv)
 			argc--;
 			argv++;
 			fullscreen = true;
+		} else if (!strcmp(argv[0], "-opacity")) {
+			argc--;
+			argv++;
+			if (!argc || argv[0][0] == '-') {
+				usage();
+			}
+			window_opacity = strtof(argv[0], NULL);
+			argc--;
+			argv++;
 		} else if (!strcmp(argv[0], "-sound")) {
 			argc--;
 			argv++;
@@ -1081,7 +1093,7 @@ main(int argc, char **argv)
 	if (!headless) {
 		SDL_Init(SDL_INIT_VIDEO | SDL_INIT_EVENTS | SDL_INIT_GAMECONTROLLER | SDL_INIT_AUDIO);
 		audio_init(audio_dev_name, audio_buffers);
-		video_init(window_scale, screen_x_scale, scale_quality, fullscreen);
+		video_init(window_scale, screen_x_scale, scale_quality, fullscreen, window_opacity);
 	}
 
 	wav_recorder_set_path(wav_path);

--- a/src/video.c
+++ b/src/video.c
@@ -287,7 +287,7 @@ video_reset()
 }
 
 bool
-video_init(int window_scale, float screen_x_scale, char *quality, bool fullscreen)
+video_init(int window_scale, float screen_x_scale, char *quality, bool fullscreen, float opacity)
 {
 	uint32_t window_flags = SDL_WINDOW_ALLOW_HIGHDPI;
 
@@ -316,6 +316,8 @@ video_init(int window_scale, float screen_x_scale, char *quality, bool fullscree
 		is_fullscreen = true;
 		SDL_SetWindowFullscreen(window, SDL_WINDOW_FULLSCREEN);
 	}
+
+	SDL_SetWindowOpacity(window, opacity);
 
 	if (record_gif != RECORD_GIF_DISABLED) {
 		if (!strcmp(gif_path+strlen(gif_path)-5, ",wait")) {
@@ -1032,12 +1034,12 @@ render_line(uint16_t y, float scan_pos_x)
 				layer_line[layer][i] = 0;
 			}
 		}
-		if (s_pos_x_p == 0) 
+		if (s_pos_x_p == 0)
 			old_layer_line_enable[layer] = layer_line_enable[layer];
 	}
 
 	// clear sprite_line if sprites get disabled
-	if (!sprite_line_enable && old_sprite_line_enable) {	
+	if (!sprite_line_enable && old_sprite_line_enable) {
 		for (uint16_t i = s_pos_x_p; i < SCREEN_WIDTH; i++) {
 			sprite_line_col[i] = 0;
 			sprite_line_z[i] = 0;
@@ -1048,7 +1050,7 @@ render_line(uint16_t y, float scan_pos_x)
 	if (s_pos_x_p == 0)
 		old_sprite_line_enable = sprite_line_enable;
 
-	
+
 
 	if (sprite_line_enable) {
 		render_sprite_line(eff_y);

--- a/src/video.h
+++ b/src/video.h
@@ -11,7 +11,7 @@
 #include <SDL.h>
 #include "glue.h"
 
-bool video_init(int window_scale, float screen_x_scale, char *quality, bool fullscreen);
+bool video_init(int window_scale, float screen_x_scale, char *quality, bool fullscreen, float opacity);
 void video_reset(void);
 bool video_step(float mhz, float steps, bool midline);
 bool video_update(void);


### PR DESCRIPTION
SDL supports window transparency (also called opacity) by means of call SDL_SetWindowOpacity(window, transparency /* (0.0,1.0) */). By default transparency is off via transparency value = 1.0 but can be user specified with parameter: -transparency (0.0..1.0). In addition some whitespace formatting are fixed.

![x16-emu-trans](https://github.com/X16Community/x16-emulator/assets/5285079/ee3e5511-883f-47f9-84b8-3da859cac5c9)
