### PR TITLE
unlink(2) can be found in unistd.h

### DIFF
--- a/src/files.c
+++ b/src/files.c
@@ -8,6 +8,7 @@
 #include <limits.h>
 #include <string.h>
 #include <stdlib.h>
+#include <unistd.h>
 #include <SDL.h>
 #include <zlib.h>
 #include <inttypes.h>


### PR DESCRIPTION
Inspired by the following build failure I get on NetBSD:

```
src/files.c: In function ‘x16open’:
src/files.c:145:4: error: implicit declaration of function ‘unlink’ [-Werror=implicit-function-declaration]
    unlink(tmp_path);
    ^~~~~~
cc1: all warnings being treated as errors
```