### PR TITLE
UI: use relative motion in grabbed mode

### DIFF
--- a/src/video.c
+++ b/src/video.c
@@ -1436,7 +1436,11 @@ video_update()
 		if (event.type == SDL_MOUSEMOTION) {
 			static int mouse_x;
 			static int mouse_y;
-			mouse_move(event.motion.x - mouse_x, event.motion.y - mouse_y);
+			if (mouse_grabbed) {
+				mouse_move(event.motion.xrel, event.motion.yrel);
+			} else {
+				mouse_move(event.motion.x - mouse_x, event.motion.y - mouse_y);
+			}
 			mouse_x = event.motion.x;
 			mouse_y = event.motion.y;
 			mouse_changed = true;


### PR DESCRIPTION
This change partially fixes #133 in that it allows full range of motion in grab mode (Ctrl+M).  There is a bounds problem in the ROM, though, where the mouse scaling isn't correct for some modes.

For instance, SCREEN MODE 2 makes it so the mouse has 960 steps from top to bottom rather than 480, which was the source of this issue showing up in the emu before this PR but never in the ROM.

Closes #133