### PR TITLE
Cartridges: fix help for fill value, treat fill value as byte

### DIFF
--- a/src/cartridge.c
+++ b/src/cartridge.c
@@ -159,7 +159,7 @@ cartridge_set_desc(const char *name)
 		namelen = CART_DESCRIPTION_SIZE;
 	}
 
-	memset(Cartridge_info.description, 0x20202020, CART_DESCRIPTION_SIZE);
+	memset(Cartridge_info.description, 0x20, CART_DESCRIPTION_SIZE);
 	memcpy(Cartridge_info.description, name, namelen);
 }
 
@@ -175,7 +175,7 @@ cartridge_set_author(const char *name)
 		namelen = CART_AUTHOR_SIZE;
 	}
 
-	memset(Cartridge_info.author, 0x20202020, CART_AUTHOR_SIZE);
+	memset(Cartridge_info.author, 0x20, CART_AUTHOR_SIZE);
 	memcpy(Cartridge_info.author, name, namelen);
 }
 
@@ -191,7 +191,7 @@ cartridge_set_copyright(const char *name)
 		namelen = CART_COPYRIGHT_SIZE;
 	}
 
-	memset(Cartridge_info.copyright, 0x20202020, CART_COPYRIGHT_SIZE);
+	memset(Cartridge_info.copyright, 0x20, CART_COPYRIGHT_SIZE);
 	memcpy(Cartridge_info.copyright, name, namelen);
 
 }
@@ -208,7 +208,7 @@ cartridge_set_program_version(const char *name)
 		namelen = CART_PROGRAM_VERSION_SIZE;
 	}
 
-	memset(Cartridge_info.prg_version, 0x20202020, CART_PROGRAM_VERSION_SIZE);
+	memset(Cartridge_info.prg_version, 0x20, CART_PROGRAM_VERSION_SIZE);
 	memcpy(Cartridge_info.prg_version, name, namelen);
 }
 
@@ -330,7 +330,7 @@ cartridge_define_bank_range(uint8_t start_bank, uint8_t end_bank, uint8_t bank_t
 }
 
 bool
-cartridge_import_files(char **bin_files, int num_files, uint8_t start_bank, uint8_t bank_type, uint32_t fill_value)
+cartridge_import_files(char **bin_files, int num_files, uint8_t start_bank, uint8_t bank_type, uint8_t fill_value)
 {
 	if(start_bank < 32) {
 		return false;
@@ -376,7 +376,7 @@ cartridge_import_files(char **bin_files, int num_files, uint8_t start_bank, uint
 }
 
 bool
-cartridge_fill(uint8_t start_bank, uint8_t end_bank, uint8_t bank_type, uint32_t fill_value)
+cartridge_fill(uint8_t start_bank, uint8_t end_bank, uint8_t bank_type, uint8_t fill_value)
 {
 	if(start_bank < 32) {
 		return false;

--- a/src/cartridge.h
+++ b/src/cartridge.h
@@ -57,8 +57,8 @@ void cartridge_get_copyright(char *buffer, size_t buffer_size);
 void cartridge_get_program_version(char *buffer, size_t buffer_size);
 
 bool cartridge_define_bank_range(uint8_t start_bank, uint8_t end_bank, uint8_t bank_type);
-bool cartridge_import_files(char **bin_files, int num_files, uint8_t start_bank, uint8_t bank_type, uint32_t fill_value);
-bool cartridge_fill(uint8_t start_bank, uint8_t end_bank, uint8_t bank_type, uint32_t fill_value);
+bool cartridge_import_files(char **bin_files, int num_files, uint8_t start_bank, uint8_t bank_type, uint8_t fill_value);
+bool cartridge_fill(uint8_t start_bank, uint8_t end_bank, uint8_t bank_type, uint8_t fill_value);
 
 bool cartridge_save(const char *cartridge_file);
 bool cartridge_save_nvram();

--- a/src/makecart.c
+++ b/src/makecart.c
@@ -10,7 +10,7 @@
 
 extern uint8_t *CART;
 
-uint32_t fill_value = 0;
+uint8_t fill_value = 0;
 
 static void parse_cmdline(int argc, char **argv);
 
@@ -94,9 +94,8 @@ usage()
 	printf("\n");
 	printf("-fill <value>\n");
 	printf("\tSet the fill value to use with any partially-filled banks of cartridge\n");
-	printf("\tmemory. Value can be defined in decimal, or in hexadecimal with a '$' or\n");
-	printf("\t'0x' prefix. 8-bit values will be repeated every byte, 16-bit values every two\n");
-	printf("\tbytes, and 32-bit values every 4 bytes.\n");
+	printf("\tmemory. Value can be defined in decimal, in hexadecimal with a '$' or\n");
+	printf("\t'0x' prefix, in octal with a leading 0, or in binary with a leading 0b or %%.\n");
 	printf("\n");
 	printf("-rom_file <start_bank> [<filenames.bin>...]\n");
 	printf("\tDefine rom banks from the specified list of files. File data is tightly\n");
@@ -427,13 +426,6 @@ parse_cmdline(int argc, char **argv)
 			}
 			++argv;
 			--argc;
-
-			if((fill_value & 0xffffff00) == 0) {
-				fill_value |= (fill_value << 8);
-			}
-			if((fill_value & 0xffff0000) == 0) {
-				fill_value |= (fill_value << 16);
-			}
 
 		} else if(!strcmp(argv[0], "-rom_file")) {
 			++argv;


### PR DESCRIPTION
memset()'s fill value is a byte rather than a 32-bit pattern.

Closes #130 