### PR TITLE
VERA: force audio subsystem render to update flag bits before returning AUDIO_CTRL state.

### DIFF
--- a/src/audio.c
+++ b/src/audio.c
@@ -229,7 +229,7 @@ audio_step(int cpu_clocks)
 		vera_samp_pos_hd = (vera_samp_pos_hd + max_cpu_clks * VERA_SAMP_CLKS_PER_CPU_CLK) & SAMP_POS_MASK_FRAC;
 		ym_samp_pos_hd = (ym_samp_pos_hd + max_cpu_clks * YM_SAMP_CLKS_PER_CPU_CLK) & SAMP_POS_MASK_FRAC;
 		cpu_clocks -= max_cpu_clks;
-		audio_render();
+		if (cpu_clocks > 0) audio_render();
 	}
 }
 

--- a/src/audio.c
+++ b/src/audio.c
@@ -229,7 +229,7 @@ audio_step(int cpu_clocks)
 		vera_samp_pos_hd = (vera_samp_pos_hd + max_cpu_clks * VERA_SAMP_CLKS_PER_CPU_CLK) & SAMP_POS_MASK_FRAC;
 		ym_samp_pos_hd = (ym_samp_pos_hd + max_cpu_clks * YM_SAMP_CLKS_PER_CPU_CLK) & SAMP_POS_MASK_FRAC;
 		cpu_clocks -= max_cpu_clks;
-		if (cpu_clocks > 0) audio_render();
+		audio_render();
 	}
 }
 

--- a/src/video.c
+++ b/src/video.c
@@ -1845,7 +1845,7 @@ uint8_t video_read(uint8_t reg, bool debugOn) {
 		case 0x19:
 		case 0x1A: return reg_layer[1][reg - 0x14];
 
-		case 0x1B: return pcm_read_ctrl();
+		case 0x1B: audio_render(); return pcm_read_ctrl();
 		case 0x1C: return pcm_read_rate();
 		case 0x1D: return 0;
 


### PR DESCRIPTION
@akumanatt This fixes #126 but I'm not fully confident that it's the correct fix.  Can you please weigh in?

It seems not to cause any adverse effects, though.

Closes #126 