### PR TITLE
I2C: defer machine reset until after i2c_step() returns

### DIFF
--- a/src/i2c.c
+++ b/src/i2c.c
@@ -31,6 +31,14 @@ uint8_t kbd_buffer[KBD_SIZE];						//Ring buffer for key codes
 #define MSE_SIZE 8
 uint8_t mse_buffer[MSE_SIZE];						//Ring buffer for mouse movement data
 
+void i2c_reset_state() {
+	state = STATE_STOP;
+	read_mode = false;
+	value = 0;
+	count = 0;
+	smc_requested_reset = false;
+}
+
 uint8_t
 i2c_read(uint8_t device, uint8_t offset) {
 	uint8_t value;

--- a/src/i2c.h
+++ b/src/i2c.h
@@ -18,6 +18,7 @@ typedef struct {
 
 extern i2c_port_t i2c_port;
 
+void i2c_reset_state();
 void i2c_step();
 
 void i2c_kbd_buffer_add(uint8_t value);

--- a/src/main.c
+++ b/src/main.c
@@ -26,6 +26,7 @@
 #include "serial.h"
 #include "i2c.h"
 #include "rtc.h"
+#include "smc.h"
 #include "vera_spi.h"
 #include "sdcard.h"
 #include "ieee.h"
@@ -291,6 +292,7 @@ void mouse_state_init(void)
 void
 machine_reset()
 {
+	i2c_reset_state();
 	ieee_init();
 	memory_reset();
 	vera_spi_init();
@@ -1254,6 +1256,7 @@ emulator_loop(void *param)
 {
 	uint32_t old_clockticks6502 = clockticks6502;
 	for (;;) {
+		if (smc_requested_reset) machine_reset();
 
 		if (testbench && pc == 0xfffd){
 			testbench_init();

--- a/src/smc.c
+++ b/src/smc.c
@@ -23,6 +23,7 @@
 
 uint8_t activity_led;
 uint8_t mse_count = 0;
+bool smc_requested_reset = false;
 
 uint8_t
 smc_read(uint8_t a) {
@@ -65,12 +66,12 @@ smc_write(uint8_t a, uint8_t v) {
 #endif
 				exit(0);
 			} else if (v == 1) {
-				machine_reset();
+				smc_requested_reset = true;
 			}
 			break;
 		case 2:
 			if (v == 0) {
-				machine_reset();
+				smc_requested_reset = true;
 			}
 			break;
 		case 3:

--- a/src/smc.h
+++ b/src/smc.h
@@ -11,4 +11,6 @@ extern void nmi6502();
 uint8_t smc_read(uint8_t offset);
 void smc_write(uint8_t offset, uint8_t value);
 
+extern bool smc_requested_reset;
+
 #endif


### PR DESCRIPTION
Before this change, requesting a reset via the SMC would leave the i2c state machine in the middle of a transaction, so the first i2c read once the kernal started to boot came back corrupt.

This PR defers the machine reset to the main loop, and provides a new i2c state machine reset function.