### PR TITLE
Windows build options needed after introducing the C++ lib

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,6 +69,7 @@ jobs:
           mkdir emu_binaries
           cp $(which SDL2.dll) emu_binaries/.
           cp $(which zlib1.dll) emu_binaries/.
+          cp $(which libwinpthread-1.dll) emu_binaries/.
           cp sdcard.img.zip emu_binaries/.
           cp x16emu.exe emu_binaries/.
           cp makecart.exe emu_binaries/.
@@ -135,6 +136,7 @@ jobs:
           mkdir emu_binaries
           cp $(which SDL2.dll) emu_binaries/.
           cp $(which zlib1.dll) emu_binaries/.
+          cp $(which libwinpthread-1.dll) emu_binaries/.
           cp sdcard.img.zip emu_binaries/.
           cp x16emu.exe emu_binaries/.
           cp makecart.exe emu_binaries/.

--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,7 @@ ifeq ($(CROSS_COMPILE_WINDOWS),1)
 	LDFLAGS+=-L$(MINGW32)/lib
 	# this enables printf() to show, but also forces a console window
 	LDFLAGS+=-Wl,--subsystem,console
+	LDFLAGS+=-static-libstdc++ -static-libgcc
 ifeq ($(TARGET_CPU),x86)
 	CC=i686-w64-mingw32-gcc
 	CXX=i686-w64-mingw32-g++


### PR DESCRIPTION
After the inclusion of C++ code, Windows builds were not viable for most systems without dev tools installed.  This should be sufficient to resolve this.