### PR TITLE
Makefile cleanup, make LTO the default

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,7 +65,7 @@ jobs:
         run: |
           git reset --hard
           git diff
-          TRACE=1 LTO=1 CROSS_COMPILE_WINDOWS=1 SDL2CONFIG=sdl2-config make V=1 -j2
+          TRACE=1 CROSS_COMPILE_WINDOWS=1 SDL2CONFIG=sdl2-config make V=1 -j2
           mkdir emu_binaries
           cp $(which SDL2.dll) emu_binaries/.
           cp $(which zlib1.dll) emu_binaries/.
@@ -132,7 +132,7 @@ jobs:
         run: |
           git reset --hard
           git diff
-          TRACE=1 LTO=1 WIN_SDL2=/mingw32 TARGET_CPU=x86 CROSS_COMPILE_WINDOWS=1 make V=1 -j2
+          TRACE=1 WIN_SDL2=/mingw32 TARGET_CPU=x86 CROSS_COMPILE_WINDOWS=1 make V=1 -j2
           mkdir emu_binaries
           cp $(which SDL2.dll) emu_binaries/.
           cp $(which zlib1.dll) emu_binaries/.
@@ -186,7 +186,7 @@ jobs:
           cp latest_rom/*.h src/.
       - name: Build Emulator
         run: |
-          TRACE=1 LTO=1 make V=1 -j3
+          TRACE=1 make V=1 -j3
           mkdir emu_binaries
           cp sdcard.img.zip emu_binaries/.
           cp x16emu emu_binaries/.
@@ -245,7 +245,7 @@ jobs:
           commands: |
             apt-get update
             apt-get install -y build-essential make libsdl2-dev file git
-            TRACE=1 LTO=1 make V=1 -j3
+            TRACE=1 make V=1 -j3
             mkdir emu_binaries
             cp sdcard.img.zip emu_binaries/.
             cp x16emu emu_binaries/.
@@ -305,7 +305,7 @@ jobs:
           commands: |
             apt-get update
             apt-get install -y build-essential make libsdl2-dev file git
-            TRACE=1 LTO=1 make V=1 -j3
+            TRACE=1 make V=1 -j3
             mkdir emu_binaries
             cp sdcard.img.zip emu_binaries/.
             cp x16emu emu_binaries/.
@@ -357,7 +357,7 @@ jobs:
           cp latest_rom/*.h src/.
       - name: Build Emulator
         run: |
-          TRACE=1 LTO=1 MAC_STATIC=1 LIBSDL_FILE=/usr/local/Cellar/sdl2/*/lib/libSDL2.a make V=1 -j3
+          TRACE=1 MAC_STATIC=1 LIBSDL_FILE=/usr/local/Cellar/sdl2/*/lib/libSDL2.a make V=1 -j3
           mkdir emu_binaries
           cp sdcard.img.zip emu_binaries/.
           cp x16emu emu_binaries/.
@@ -409,7 +409,7 @@ jobs:
           cp latest_rom/rom.bin .
       - name: Build Emulator
         run: |
-          LTO=1 make V=1 -j3 wasm
+          make V=1 -j3 wasm
           mkdir emu_binaries
           cp x16emu.data x16emu.html x16emu.js x16emu.wasm emu_binaries/
           mkdir emu_binaries/webassembly

--- a/Makefile
+++ b/Makefile
@@ -4,16 +4,6 @@
 #
 ##################################################################################################
 
-# the mingw-w64 path on macOS installed through homebrew
-ifndef MINGW32
-	MINGW32=/opt/homebrew/Cellar/mingw-w64/9.0.0_4/toolchain-x86_64/x86_64-w64-mingw32
-endif
-# the Windows SDL2 path on macOS installed through
-# ./configure  --host=x86_64-w64-mingw32 --prefix=... && make && make install
-ifndef WIN_SDL2
-	WIN_SDL2=~/tmp/sdl2-win32
-endif
-
 ifeq ($(CROSS_COMPILE_WINDOWS),1)
 	SDL2CONFIG?=$(WIN_SDL2)/bin/sdl2-config --prefix=$(WIN_SDL2)
 else
@@ -25,7 +15,7 @@ CXXFLAGS=-std=c++17 -O3 -Wall -Werror -Isrc/extern/ymfm/src
 LDFLAGS=$(shell $(SDL2CONFIG) --libs) -lm -lz
 
 # build with link time optimization
-ifdef LTO
+ifndef NOLTO
 	CFLAGS+=-flto
 	LDFLAGS+=-flto
 endif
@@ -48,7 +38,6 @@ GIT_REV=$(shell git diff --quiet && echo -n $$(git rev-parse --short=8 HEAD || /
 CFLAGS+=-D GIT_REV='"$(GIT_REV)"'
 
 ifeq ($(MAC_STATIC),1)
-	LIBSDL_FILE?=/opt/homebrew/Cellar/sdl2/2.0.20/lib/libSDL2.a
 	LDFLAGS=$(LIBSDL_FILE) -lm -liconv -lz -Wl,-framework,CoreAudio -Wl,-framework,AudioToolbox -Wl,-framework,ForceFeedback -lobjc -Wl,-framework,CoreVideo -Wl,-framework,Cocoa -Wl,-framework,Carbon -Wl,-framework,IOKit -Wl,-weak_framework,QuartzCore -Wl,-weak_framework,Metal -Wl,-weak_framework,CoreHaptics -Wl,-weak_framework,GameController
 endif
 
@@ -113,7 +102,7 @@ cpu/tables.h cpu/mnemonics.h: cpu/buildtables.py cpu/6502.opcodes cpu/65c02.opco
 $(X16_SDIR)/%.h:;
 $(MAKECART_SDIR)/%.h:;
 
-# WebASssembly/emscripten target
+# WebAssembly/emscripten target
 #
 # See webassembly/WebAssembly.md
 wasm:
@@ -126,94 +115,3 @@ ifeq ($(filter $(MAKECMDGOALS), clean),)
 -include $(X16_DEPS)
 -include $(MAKECART_DEPS)
 endif
-
-##################################################################################################
-
-##################################################################################################
-#
-# PACKAGING
-#
-# Packaging is tricky and partially depends on Michael's specific setup. :/
-#
-# * The Mac build is done on a Mac.
-# * The Windows build is cross-compiled on the Mac using mingw. For more info, see:
-#   https://blog.wasin.io/2018/10/21/cross-compile-sdl2-library-and-app-on-windows-from-macos.html
-# * The Linux build is done by sshing into a VMware Ubuntu machine that has the same
-#   directory tree mounted. Since unlike on Windows and Mac, there are 0 libraries guaranteed
-#   to be present, a static build would mean linking everything that is not the kernel. And since
-#   there are always 3 ways of doing something on Linux, it would mean including three graphics
-#   and three sounds backends. Therefore, the Linux build uses dynamic linking, requires libsdl2
-#   to be installed and might only work on the version of Linux I used for building, which is the
-#   current version of Ubuntu.
-# * For converting the documentation from Markdown to HTML, pandoc is required:
-#   brew install pandoc
-#
-##################################################################################################
-
-# hostname of the Linux VM
-LINUX_COMPILE_HOST = ubuntu.local
-# path to the equivalent of `pwd` on the Mac
-LINUX_BASE_DIR = /tmp/
-
-TMPDIR_NAME=TMP-x16emu-package
-
-define add_extra_files_to_package
-	# ROMs
-	cp ../x16-rom/build/x16/rom.bin $(TMPDIR_NAME)
-	cp ../x16-rom/build/x16/kernal.sym  $(TMPDIR_NAME)
-	cp ../x16-rom/build/x16/keymap.sym  $(TMPDIR_NAME)
-	cp ../x16-rom/build/x16/dos.sym     $(TMPDIR_NAME)
-	cp ../x16-rom/build/x16/basic.sym   $(TMPDIR_NAME)
-	cp ../x16-rom/build/x16/monitor.sym $(TMPDIR_NAME)
-	cp ../x16-rom/build/x16/charset.sym $(TMPDIR_NAME)
-
-	# Empty SD card image
-	cp sdcard.img.zip $(TMPDIR_NAME)
-
-	# Documentation
-	mkdir $(TMPDIR_NAME)/docs
-	pandoc --from gfm --to html -c github-pandoc.css --standalone --metadata pagetitle="Commander X16 Emulator" README.md --output $(TMPDIR_NAME)/docs/README.html
-	pandoc --from gfm --to html -c github-pandoc.css --standalone --metadata pagetitle="Commander X16 KERNAL/BASIC/DOS ROM"  ../x16-rom/README.md --output $(TMPDIR_NAME)/docs/KERNAL-BASIC.html
-	pandoc --from gfm --to html -c github-pandoc.css --standalone --metadata pagetitle="Commander X16 Programmer's Reference Guide"  ../x16-docs/Commander\ X16\ Programmer\'s\ Reference\ Guide.md --output $(TMPDIR_NAME)/docs/Programmer\'s\ Reference\ Guide.html --lua-filter=mdtohtml.lua
-	for IN in ../x16-docs/X16\ Reference\ *; do \
-		OUT=$$(basename "$$IN" .md).html; \
-		pandoc --from gfm --to html -c github-pandoc.css --standalone --metadata pagetitle="Commander X16 Programmer's Reference Guide" "$$IN" --output "$(TMPDIR_NAME)/docs/$$OUT" --lua-filter=mdtohtml.lua; \
-	done
-	pandoc --from gfm --to html -c github-pandoc.css --standalone --metadata pagetitle="VERA Programmer's Reference.md"  ../x16-docs/VERA\ Programmer\'s\ Reference.md --output $(TMPDIR_NAME)/docs/VERA\ Programmer\'s\ Reference.html
-	cp github-pandoc.css $(TMPDIR_NAME)/docs
-endef
-
-package: package_mac package_win package_linux
-	make clean
-
-package_mac:
-	(cd ../x16-rom/; make clean all)
-	MAC_STATIC=1 make clean all
-	rm -rf $(TMPDIR_NAME) x16emu_mac.zip
-	mkdir $(TMPDIR_NAME)
-	cp x16emu makecart $(TMPDIR_NAME)
-	$(call add_extra_files_to_package)
-	(cd $(TMPDIR_NAME)/; zip -r "../x16emu_mac.zip" *)
-	rm -rf $(TMPDIR_NAME)
-
-package_win:
-	(cd ../x16-rom/; make clean all)
-	CROSS_COMPILE_WINDOWS=1 make clean all
-	rm -rf $(TMPDIR_NAME) x16emu_win.zip
-	mkdir $(TMPDIR_NAME)
-	cp x16emu.exe makecart.exe $(TMPDIR_NAME)
-	cp $(WIN_SDL2)/bin/SDL2.dll $(TMPDIR_NAME)/
-	$(call add_extra_files_to_package)
-	(cd $(TMPDIR_NAME)/; zip -r "../x16emu_win.zip" *)
-	rm -rf $(TMPDIR_NAME)
-
-package_linux:
-	(cd ../x16-rom/; make clean all)
-	(cd ..; tar cp x16-rom x16-emulator x16-docs | ssh $(LINUX_COMPILE_HOST) "cd $(LINUX_BASE_DIR); tar xp")
-	ssh $(LINUX_COMPILE_HOST) "cd $(LINUX_BASE_DIR)/x16-emulator; make clean all"
-	rm -rf $(TMPDIR_NAME) x16emu_linux.zip
-	mkdir $(TMPDIR_NAME)
-	scp $(LINUX_COMPILE_HOST):$(LINUX_BASE_DIR)/x16-emulator/x16emu $(LINUX_COMPILE_HOST):$(LINUX_BASE_DIR)/x16-emulator/makecart $(TMPDIR_NAME)
-	$(call add_extra_files_to_package)
-	(cd $(TMPDIR_NAME)/; zip -r "../x16emu_linux.zip" *)
-	rm -rf $(TMPDIR_NAME)


### PR DESCRIPTION
Removed the mist64-specific build section and options out of the Makefile.

Enable link-time optimization by default.