### PR TITLE
fix recent clang builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ else
 	SDL2CONFIG=sdl2-config
 endif
 
-CFLAGS=-std=c99 -O3 -Wall -Werror -Wno-unknown-pragmas -g $(shell $(SDL2CONFIG) --cflags) -Isrc/extern/include
+CFLAGS=-std=c99 -O3 -Wall -Werror -g $(shell $(SDL2CONFIG) --cflags) -Isrc/extern/include
 CXXFLAGS=-std=c++17 -O3 -Wall -Werror -Isrc/extern/ymfm/src
 LDFLAGS=$(shell $(SDL2CONFIG) --libs) -lm -lz
 

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ else
 	SDL2CONFIG=sdl2-config
 endif
 
-CFLAGS=-std=c99 -O3 -Wall -Werror -g $(shell $(SDL2CONFIG) --cflags) -Isrc/extern/include
+CFLAGS=-std=c99 -O3 -Wall -Werror -Wno-unknown-pragmas -g $(shell $(SDL2CONFIG) --cflags) -Isrc/extern/include
 CXXFLAGS=-std=c++17 -O3 -Wall -Werror -Isrc/extern/ymfm/src
 LDFLAGS=$(shell $(SDL2CONFIG) --libs) -lm -lz
 

--- a/src/extern/ymfm/src/ymfm.h
+++ b/src/extern/ymfm/src/ymfm.h
@@ -37,7 +37,9 @@
  #define _CRT_SECURE_NO_WARNINGS
 #endif
 
+#if defined(__clang__)
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#endif
 
 #include <cassert>
 #include <cstdint>

--- a/src/extern/ymfm/src/ymfm.h
+++ b/src/extern/ymfm/src/ymfm.h
@@ -37,6 +37,8 @@
  #define _CRT_SECURE_NO_WARNINGS
 #endif
 
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+
 #include <cassert>
 #include <cstdint>
 #include <cstdio>


### PR DESCRIPTION
Fix recent clang deprecated warning/errors due to sprintf use in ymfm package.  Fixed with clang pragma protected by clang ifdef.