### PR TITLE
HostFS: speed up type filter on large directories

### DIFF
--- a/src/ieee.c
+++ b/src/ieee.c
@@ -168,6 +168,8 @@ utf8_to_iso_string(uint8_t *dst, const uint8_t *src)
 		so = utf8_decode(so, &cp, &e);
 		if (e) {
 			dst[i] = '?';
+		} else if (cp == ',') { // commas aren't valid filename characters
+			dst[i] = '?';
 		} else {
 			dst[i] = iso8859_15_from_unicode(cp);
 		}

--- a/src/ieee.c
+++ b/src/ieee.c
@@ -168,10 +168,23 @@ utf8_to_iso_string(uint8_t *dst, const uint8_t *src)
 		so = utf8_decode(so, &cp, &e);
 		if (e) {
 			dst[i] = '?';
-		} else if (cp == ',') { // commas aren't valid filename characters
-			dst[i] = '?';
 		} else {
-			dst[i] = iso8859_15_from_unicode(cp);
+			switch (cp) {
+				case ',':
+				case '"':
+				case '*':
+				case ':':
+				case '\\':
+				case '<':
+				case '>':
+				case '|':
+					// these are not valid in filenames on FAT32 but might be encountered on hostfs
+					dst[i] = '?';
+					break;
+				default:
+					dst[i] = iso8859_15_from_unicode(cp);
+					break;
+			}
 		}
 	}
 


### PR DESCRIPTION
The prior code resolved the name within the context of HostFS first, which does a stat() for every part of the path.  This became problematic if we entered a directory with thousands of files but few directories. `DOS"$:=D"` would stall inside of HostFS code, starving the 65C02 of execution time.

This change is much faster at getting us past the negative matches and returning to 6502 execution much more quickly even in moderately large directories.