### PR TITLE
add ctrl-N/cmd-N generates NMI/RESTORE key

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ Functions while running
 * `Ctrl` + `M` will toggle mouse capture mode.
 * `Ctrl` + `P` will write a screenshot in PNG format to disk.
 * `Ctrl` + `R` will reset the computer.
+* `Ctrl` + `N` will send an NMI to the computer (like RESTORE key).
 * `Ctrl` + `S` will save a system dump configurable with `-dump`) to disk.
 * `Ctrl` + `V` will paste the clipboard by injecting key presses.
 * `Ctrl` + `=` and `Ctrl` + `+` will toggle warp mode.
@@ -190,6 +191,7 @@ Functions while running
 * `⇧⌘M` will toggle mouse capture mode.
 * `⌘P` will write a screenshot in PNG format to disk.
 * `⌘R` will reset the computer.
+* `⌘N` will send an NMI to the computer (like RESTORE key).
 * `⌘S` will save a system dump (configurable with `-dump`) to disk.
 * `⌘V` will paste the clipboard by injecting key presses.
 * `⌘=` and `⇧⌘+` will toggle warp mode.

--- a/src/glue.h
+++ b/src/glue.h
@@ -78,6 +78,7 @@ extern bool enable_midline;
 
 extern void machine_dump(const char* reason);
 extern void machine_reset();
+extern void machine_nmi();
 extern void machine_paste(char *text);
 extern void machine_toggle_warp();
 extern void init_audio();

--- a/src/main.c
+++ b/src/main.c
@@ -306,6 +306,12 @@ machine_reset()
 }
 
 void
+machine_nmi()
+{
+	nmi6502();
+}
+
+void
 machine_paste(char *s)
 {
 	if (s) {

--- a/src/video.c
+++ b/src/video.c
@@ -1360,6 +1360,9 @@ video_update()
 				} else if (event.key.keysym.sym == SDLK_r) {
 					machine_reset();
 					consumed = true;
+				} else if (event.key.keysym.sym == SDLK_n) {
+					machine_nmi();
+					consumed = true;
 				} else if (event.key.keysym.sym == SDLK_v) {
 					machine_paste(SDL_GetClipboardText());
 					consumed = true;


### PR DESCRIPTION
Added handy ctrl-N or cmd-N NMI or RESTORE key.  It is similar to reset, but nothing new needed for SMC AFAICT.