### PR TITLE
Mouse capture hotkey also grabs system keyboard hotkeys

### DIFF
--- a/src/glue.h
+++ b/src/glue.h
@@ -23,9 +23,9 @@
 #define WINDOW_TITLE "Commander X16"
 
 #ifdef __APPLE__
-#define MOUSE_GRAB_MSG " (\xE2\x87\xA7\xE2\x8C\x98M to release mouse)"
+#define MOUSE_GRAB_MSG " (\xE2\x87\xA7\xE2\x8C\x98M to end mouse/keyboard capture)"
 #else
-#define MOUSE_GRAB_MSG " (Ctrl+M to release mouse)"
+#define MOUSE_GRAB_MSG " (Ctrl+M to end mouse/keyboard capture)"
 #endif
 
 typedef enum {

--- a/src/video.c
+++ b/src/video.c
@@ -524,6 +524,7 @@ void
 mousegrab_toggle() {
 	mouse_grabbed = !mouse_grabbed;
 	SDL_SetRelativeMouseMode(mouse_grabbed);
+	SDL_SetWindowKeyboardGrab(window, mouse_grabbed);
 	SDL_ShowCursor((mouse_grabbed || kernal_mouse_enabled) ? SDL_DISABLE : SDL_ENABLE);
 	sprintf(window_title, WINDOW_TITLE "%s", mouse_grabbed ? MOUSE_GRAB_MSG : "");
 	video_update_title(window_title);

--- a/src/video.c
+++ b/src/video.c
@@ -308,6 +308,7 @@ video_init(int window_scale, float screen_x_scale, char *quality, bool fullscree
 	video_reset();
 
 	SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, quality);
+	SDL_SetHint(SDL_HINT_GRAB_KEYBOARD, "1"); // Grabs keyboard shortcuts from the system during window grab
 	SDL_CreateWindowAndRenderer(SCREEN_WIDTH * window_scale * screen_x_scale, SCREEN_HEIGHT * window_scale, window_flags, &window, &renderer);
 #ifndef __MORPHOS__
 	SDL_SetWindowResizable(window, true);

--- a/src/video.c
+++ b/src/video.c
@@ -523,8 +523,7 @@ struct video_sprite_properties
 void
 mousegrab_toggle() {
 	mouse_grabbed = !mouse_grabbed;
-	SDL_SetRelativeMouseMode(mouse_grabbed);
-	SDL_SetWindowKeyboardGrab(window, mouse_grabbed);
+	SDL_SetWindowGrab(window, mouse_grabbed);
 	SDL_ShowCursor((mouse_grabbed || kernal_mouse_enabled) ? SDL_DISABLE : SDL_ENABLE);
 	sprintf(window_title, WINDOW_TITLE "%s", mouse_grabbed ? MOUSE_GRAB_MSG : "");
 	video_update_title(window_title);


### PR DESCRIPTION
This allows the emu to capture more keystroke combinations from the host that would otherwise trigger desktop environment actions while the mouse is also captured, such as alt-tab, or certain F-keys on Mac