### PR TITLE
fix compiler error on mingw g++

### DIFF
--- a/src/extern/ymfm/src/ymfm_opm.cpp
+++ b/src/extern/ymfm/src/ymfm_opm.cpp
@@ -144,7 +144,7 @@ void opm_registers::operator_map(operator_mapping &dest) const
 
 bool opm_registers::write(uint16_t index, uint8_t data, uint32_t &channel, uint32_t &opmask)
 {
-	assert(index < REGISTERS);
+	if(index >= REGISTERS) return false;
 
 	// LFO AM/PM depth are written to the same register (0x19);
 	// redirect the PM depth to an unused neighbor (0x1a)


### PR DESCRIPTION
When attempting a windows cross-compile on linux:

```
$ WIN_SDL2=/usr/x86_64-w64-mingw32/ CROSS_COMPILE_WINDOWS=1 make   

x86_64-w64-mingw32-g++ -std=c++17 -O3 -Wall -Werror -Isrc/extern/ymfm/src -c src/extern/ymfm/src/ymfm_opm.cpp -MD -MT build/x16emu/extern/ymfm/src/ymfm_opm.o -MF build/x16emu/extern/ymfm/src/ymfm_opm.d -o build/x16emu/extern/ymfm/src/ymfm_opm.o
src/extern/ymfm/src/ymfm_opm.cpp: In member function ‘bool ymfm::opm_registers::write(uint16_t, uint8_t, uint32_t&, uint32_t&)’:
src/extern/ymfm/src/ymfm_opm.cpp:154:34: error: writing 1 byte into a region of size 0 [-Werror=stringop-overflow=]
  154 |                 m_regdata[index] = data;
      |                 ~~~~~~~~~~~~~~~~~^~~~~~
In file included from src/extern/ymfm/src/ymfm_opm.cpp:31:
src/extern/ymfm/src/ymfm_opm.h:239:17: note: at offset 256 into destination object ‘ymfm::opm_registers::m_regdata’ of size 256
  239 |         uint8_t m_regdata[REGISTERS];         // register data
      |                 ^~~~~~~~~
```


The error occurs when trying to do a cross-compile for windows. in this particular case using x86_64-w64-mingw32-g++ (GCC) 12.2.0

Apparently the mingw compiler is not happy enough with the assert. Replacing with an if shuts up the compiler error and allows to cross-compile a windows build again.

By the way, on my "regular" native compiles on Linux, the error does not occur. Even with a version 12 g++ compiler on another linux box. (that version corresponding to the mingw version of the compiler)... which strikes me as odd
