### PR TITLE
Enhance cycle counter debug, add emu stdout and debug ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,18 @@ With the argument `-wav`, followed by a filename, an audio recording will be sav
 If the option `,wait` is specified after the filename, it will start recording on `POKE $9FB6,1`. If the option `,auto` is specified after the filename, it will start recording on the first non-zero audio signal. It will pause recording on `POKE $9FB6,0`. `PEEK($9FB6)` returns a 1 if recording is enabled but not active.
 
 
+Debug I/O registers
+-------------------
+In addition to the built-in debugger. x16-emulator exposes 4 registers, from `$9FB8`-`$9FBB`, which can be used to facilitate debugging a machine language program. 
+
+| Register | Read Behavior | Write Behavior |
+|-|-|-|
+| \$9FB8 | Latches the cpu clock counter and returns bits 0-7 | Resets the cpu clock counter to 0 |
+| \$9FB9 | Returns bits 8-15 from the latched cpu clock counter value | Outputs `"User debug 1: $xx"` to the console with xx replaced by the value written. |
+| \$9FBA | Returns bits 16-23 from the latched cpu clock counter value | Outputs `"User debug 2: $xx"` to the console with xx replaced by the value written. |
+| \$9FBB | Returns bits 24-31 from the latched cpu clock counter value | Outputs the given character to the console. This is basically a STDOUT port for programs running in the emulator. Only printable characters are allowed. Nonprintables are replaced with &#xfffd;.
+
+
 BASIC and the Screen Editor
 ---------------------------
 

--- a/src/iso_8859_15.c
+++ b/src/iso_8859_15.c
@@ -3,6 +3,8 @@
 // All rights reserved. License: 2-clause BSD
 
 #include <stdint.h>
+#include <stdio.h>
+#include "utf8_encode.h"
 
 uint8_t
 iso8859_15_from_unicode(uint32_t c)
@@ -80,3 +82,11 @@ unicode_from_iso8859_15(uint8_t c)
 	}
 }
 
+// converts the character to UTF-8 and prints it
+void
+print_iso8859_15_char(char c)
+{
+	char utf8[5];
+	utf8_encode(utf8, unicode_from_iso8859_15(c));
+	printf("%s", utf8);
+}

--- a/src/iso_8859_15.h
+++ b/src/iso_8859_15.h
@@ -5,5 +5,5 @@
 
 uint8_t iso8859_15_from_unicode(uint32_t c);
 uint32_t unicode_from_iso8859_15(uint8_t c);
-
+void print_iso8859_15_char(char c);
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -35,7 +35,6 @@
 #include "utf8.h"
 #include "iso_8859_15.h"
 #include "joystick.h"
-#include "utf8_encode.h"
 #include "rom_symbols.h"
 #include "ymglue.h"
 #include "audio.h"
@@ -328,15 +327,6 @@ machine_toggle_warp()
 	timing_init();
 }
 
-
-// converts the character to UTF-8 and prints it
-static void
-print_iso8859_15_char(char c)
-{
-	char utf8[5];
-	utf8_encode(utf8, unicode_from_iso8859_15(c));
-	printf("%s", utf8);
-}
 
 static bool
 is_kernal()

--- a/src/memory.c
+++ b/src/memory.c
@@ -346,6 +346,7 @@ emu_recorder_set(gif_recorder_command_t command)
 // 9: read: cpu clock bits 8-15
 // 10: write: output debug byte 2
 // 10: read: cpu clock bits 16-23
+// 11: write: write character to STDOUT of console
 // 11: read: cpu clock MSB bits 24-31
 // POKE $9FB3,1:PRINT"ECHO MODE IS ON":POKE $9FB3,0
 void

--- a/src/memory.c
+++ b/src/memory.c
@@ -16,6 +16,7 @@
 #include "wav_recorder.h"
 #include "audio.h"
 #include "cartridge.h"
+#include "iso_8859_15.h"
 
 uint8_t ram_bank;
 uint8_t rom_bank;
@@ -29,6 +30,9 @@ static uint8_t addr_ym = 0;
 bool randomizeRAM = false;
 bool reportUninitializedAccess = false;
 bool *RAM_access_flags;
+
+static uint32_t clock_snap = 0UL;
+static uint32_t clock_base = 0UL;
 
 #define DEVICE_EMULATOR (0x9fb0)
 
@@ -335,6 +339,14 @@ emu_recorder_set(gif_recorder_command_t command)
 // 4: save_on_exit
 // 5: record_gif
 // 6: record_wav
+// 7: cmd key toggle
+// 8: write: reset cpu clock counter
+// 8: read: snapshots cpu clock counter and reads the LSB bits 0-7
+// 9: write: output debug byte 1
+// 9: read: cpu clock bits 8-15
+// 10: write: output debug byte 2
+// 10: read: cpu clock bits 16-23
+// 11: read: cpu clock MSB bits 24-31
 // POKE $9FB3,1:PRINT"ECHO MODE IS ON":POKE $9FB3,0
 void
 emu_write(uint8_t reg, uint8_t value)
@@ -349,6 +361,19 @@ emu_write(uint8_t reg, uint8_t value)
 		case 5: emu_recorder_set((gif_recorder_command_t) value); break;
 		case 6: wav_recorder_set((wav_recorder_command_t) value); break;
 		case 7: disable_emu_cmd_keys = v; break;
+		case 8: clock_base = clockticks6502; break;
+		case 9: printf("User debug 1: $%02x\n", value); break;
+		case 10: printf("User debug 2: $%02x\n", value); break;
+		case 11: {
+			if (value == 0x09 || value == 0x0a || value == 0x0d || (value >= 0x20 && value < 0x7f)) {
+				printf("%c", value);
+			} else if (value >= 0xa1) {
+				print_iso8859_15_char((char) value);
+			} else {
+				printf("\xef\xbf\xbd"); // �
+			}
+			break;
+		}
 		default: printf("WARN: Invalid register %x\n", DEVICE_EMULATOR + reg);
 	}
 }
@@ -374,13 +399,14 @@ emu_read(uint8_t reg, bool debugOn)
 		return disable_emu_cmd_keys ? 1 : 0;
 
 	} else if (reg == 8) {
-		return (clockticks6502 >> 0) & 0xff;
+		clock_snap = clockticks6502 - clock_base;
+		return (clock_snap >> 0) & 0xff;
 	} else if (reg == 9) {
-		return (clockticks6502 >> 8) & 0xff;
+		return (clock_snap >> 8) & 0xff;
 	} else if (reg == 10) {
-		return (clockticks6502 >> 16) & 0xff;
+		return (clock_snap >> 16) & 0xff;
 	} else if (reg == 11) {
-		return (clockticks6502 >> 24) & 0xff;
+		return (clock_snap >> 24) & 0xff;
 
 	} else if (reg == 13) {
 		return keymap;


### PR DESCRIPTION
This PR changes the behavior of the emu I/O ports `$9FB8`-`$9FBB`

To reset the CPU clock counter for this purpose:
1) write a value into `$9FB8` (any value will do). This starts the timer at 0
2) run your measured section of code
3) read `$9FB8`-`$9FBB` **in that order**, which gives a 32-bit little-endian CPU clock elapsed value since step 1.  The read of `$9FB8` will snapshot (aka latch) the counter (like a "lap" button on a stopwatch) so that reads from  the subsequent registers are consistent.  Additional reads of `$9FB8` will snapshot the cpu clock once again from that point.

This change also adds three writable emulator registers that can be used for debug:
1) a write to `$9FB9` will output the text `User debug 1: $xx` showing the value written
2) a write to `$9FBA` will output the text `User debug 2: $xx` showing the value written
3) a write to `$9FBB` will print the associated ISO code to the console. This is basically a STDOUT port for the emu.  Only printable characters and whitespace are allowed.  Characters $A1 and above are printed as UTF-8 representations of their ISO codes.
