### PR TITLE
don't loop on EOF in testbench anymore, instead exit nicely

### DIFF
--- a/src/testbench.c
+++ b/src/testbench.c
@@ -72,6 +72,11 @@ void testbench_init()
     while (!init_done) {
         size_t len = get_testline(&line, &slen, stdin);     //Read command from stdin
 
+		if(len==0) {
+			puts("Exit testbench.");
+			exit(0);
+		}
+
         if (strncmp(line, "RAM", 3) == 0) {                 //Set RAM bank
             if (len < 7) {
                 invalid();


### PR DESCRIPTION
previously when starting with -testbench, it got in an endless error loop when you hit ^D (EOF)