### PR TITLE
Set mouse mode to relative when grabbed

### DIFF
--- a/src/video.c
+++ b/src/video.c
@@ -535,6 +535,7 @@ void
 mousegrab_toggle() {
 	mouse_grabbed = !mouse_grabbed;
 	SDL_SetWindowGrab(window, mouse_grabbed);
+	SDL_SetRelativeMouseMode(mouse_grabbed);
 	SDL_ShowCursor((mouse_grabbed || kernal_mouse_enabled) ? SDL_DISABLE : SDL_ENABLE);
 	sprintf(window_title, WINDOW_TITLE "%s", mouse_grabbed ? MOUSE_GRAB_MSG : "");
 	video_update_title(window_title);


### PR DESCRIPTION
I had thought SDL_SetWindowGrab() was implicitly doing this as well, but apparently this is not so.