### PR TITLE
Prevent IEEE intercept when hostfs device is not being addressed.

### DIFF
--- a/src/ieee.h
+++ b/src/ieee.h
@@ -4,12 +4,12 @@
 
 void ieee_init();
 int SECOND(uint8_t a);
-void TKSA(uint8_t a);
+int TKSA(uint8_t a);
 int ACPTR(uint8_t *a);
 int CIOUT(uint8_t a);
-void UNTLK(void);
+int UNTLK(void);
 int UNLSN(void);
-void LISTEN(uint8_t a);
-void TALK(uint8_t a);
+int LISTEN(uint8_t a);
+int TALK(uint8_t a);
 int MACPTR(uint16_t addr, uint16_t *count, uint8_t stream_mode);
 int MCIOUT(uint16_t addr, uint16_t *count, uint8_t stream_mode);

--- a/src/main.c
+++ b/src/main.c
@@ -1200,26 +1200,45 @@ handle_ieee_intercept()
 		}
 		case 0xFF93:
 			s=SECOND(a);
+			if (s == -2) {
+				handled = false;
+			}
 			break;
 		case 0xFF96:
 			TKSA(a);
+			if (s == -2) {
+				handled = false;
+			}
 			break;
 		case 0xFFA5:
 			s=ACPTR(&a);
-			status = (status & ~3) | (!a << 1); // unconditional CLC, and set zero flag based on byte read
+			if (s == -2) {
+				handled = false;
+			} else {
+				status = (status & ~3) | (!a << 1); // unconditional CLC, and set zero flag based on byte read
+			}
 			break;
 		case 0xFFA8:
 			s=CIOUT(a);
-			status = (status & ~1); // unconditonal CLC
+			if (s == -2) {
+				handled = false;
+			} else {
+				status = (status & ~1); // unconditonal CLC
+			}
 			break;
 		case 0xFFAB:
-			UNTLK();
+			s=UNTLK();
+			if (s == -2) {
+				handled = false;
+			}
 			break;
 		case 0xFFAE:
 			s=UNLSN();
 			if (s == -2) { // special error behavior
 				status = (status | 1); // SEC
 				s = 0x42;
+			} else if (s == -3) {
+				handled = false;
 			} else {
 				status = (status & ~1); // CLC
 			}
@@ -1234,10 +1253,20 @@ handle_ieee_intercept()
 			}
 			break;
 		case 0xFFB1:
-			LISTEN(a);
+			s=LISTEN(a);
+			if (s == -2) {
+				handled = false;
+			} else {
+				status = (status & ~1); // unconditonal CLC
+			}
 			break;
 		case 0xFFB4:
-			TALK(a);
+			s=TALK(a);
+			if (s == -2) {
+				handled = false;
+			} else {
+				status = (status & ~1); // unconditonal CLC
+			}
 			break;
 		default:
 			handled = false;


### PR DESCRIPTION
This PR addresses #193 and contains the following change:

The function `handle_ieee_intercept()` has been updated to only intercept Kernal IEEE calls when the virtual hostfs device is being addressed. Otherwise, no intercept takes place.

I referenced `x16-rom/dos/main.s` and `x16-rom/kernal/ieee_switch.s` to make sure I was adding the right behavior compared to the SD card:
- `TALK` and `LISTEN` check that the hostfs device is being addressed, and if not, passes through to the Kernal.
- `SECOND`, `UNLSN`, and `CIOUT` check that the hostfs device is currently listening, and if not, passes through to the Kernal.
- `TKSA`, `UNTLK`, and `ACPTR` check that the hostfs device is currently talking, and if not, passes through to the Kernal.
- `MACPTR` and `MCIOUT` are OK as-is, because these functions are only supported by hostfs and will already return the correct error code.

I did some basic tests and everything seems to work, and more importantly, the intercepts no longer clobber the other device numbers.