### PR TITLE
Miscellaneous adjustments related to timing, increase abufs when using hostfs

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,13 +100,13 @@ When starting `x16emu` without arguments, it will pick up the system ROM (`rom.b
 * `-joy1`, `-joy2`, `-joy3`, `-joy4` enables binding a gamepad to that SNES controller port
 * `-nvram` lets you specify a 64 byte file for the system's non-volatile RAM. If it does not exist, it will be created once the NVRAM is modified.
 * `-keymap` tells the KERNAL to switch to a specific keyboard layout. Use it without an argument to view the supported layouts.
-* `-noemucmdkeys`  Disable emulator command keys.
+* `-noemucmdkeys`  Disable emulator command keys. `Ctrl+M`/`⇧⌘M` will always be intercepted by the emulator.
 * `-capture` starts the emulator with the mouse/keyboard captured
 * `-sdcard` lets you specify an SD card image (partition table + FAT32). Without this option, drive 8 will interface to the current directory on the host.
 * `-fsroot <dir>` specifies a file system root for the HostFS interface. This lets you save and load files without an SD card image. (As of R42, this is the preferred method.) Default is the current working directory.
 * `-startin <dir>` specify the host filesystem directory path that the emulated filesystem starts in. Default is the current working directory if it lies within the hierarchy of fsroot, otherwise it defaults to fsroot itself.
 * `-serial` makes accesses to the host filesystem go through the Serial Bus [experimental].
-* `-nohostieee` disables IEEE API interception to access the host fs. IEEE API host fs is normally enabled unless -sdcard or -serial is specified.
+* `-nohostieee` or `-nohostfs` disables IEEE API interception to access the host fs. IEEE API HostFS is normally enabled unless `-sdcard` or `-serial` is specified.
 * `-warp` causes the emulator to run as fast as possible, possibly faster than a real X16.
 * `-gif <filename>[,wait]` to record the screen into a GIF. See below for more info.
 * `-wav <filename>[{,wait|,auto}]` to record audio into a WAV. See below for more info.

--- a/src/audio.c
+++ b/src/audio.c
@@ -83,6 +83,8 @@ static int16_t psg_buf[2 * SAMPLES_PER_BUFFER];
 static int16_t pcm_buf[2 * SAMPLES_PER_BUFFER];
 static int16_t ym_buf[2 * SAMPLES_PER_BUFFER];
 
+static bool abufmsg = false;
+
 uint32_t host_sample_rate = 0;
 
 static void
@@ -352,6 +354,10 @@ audio_render()
 	}
 	buffer_written += len * 2;
 	if (buffer_written > buffer_size) {
+		if (!abufmsg && !warp_mode) {
+			printf("Audio buffer overrun: considering increasing the size of -abufs\n");
+			abufmsg = true;
+		}
 		// Prevent the buffer from overflowing by skipping the read pointer ahead.
 		uint32_t buffer_skip_amount = (buffer_written / buffer_size) * SAMPLES_PER_BUFFER * 2;
 		rdidx = (rdidx + buffer_skip_amount) % buffer_size;

--- a/src/audio.c
+++ b/src/audio.c
@@ -83,8 +83,6 @@ static int16_t psg_buf[2 * SAMPLES_PER_BUFFER];
 static int16_t pcm_buf[2 * SAMPLES_PER_BUFFER];
 static int16_t ym_buf[2 * SAMPLES_PER_BUFFER];
 
-static bool abufmsg = false;
-
 uint32_t host_sample_rate = 0;
 
 static void
@@ -354,10 +352,6 @@ audio_render()
 	}
 	buffer_written += len * 2;
 	if (buffer_written > buffer_size) {
-		if (!abufmsg && !warp_mode) {
-			printf("Audio buffer overrun: considering increasing the size of -abufs\n");
-			abufmsg = true;
-		}
 		// Prevent the buffer from overflowing by skipping the read pointer ahead.
 		uint32_t buffer_skip_amount = (buffer_written / buffer_size) * SAMPLES_PER_BUFFER * 2;
 		rdidx = (rdidx + buffer_skip_amount) % buffer_size;

--- a/src/main.c
+++ b/src/main.c
@@ -1022,7 +1022,7 @@ main(int argc, char **argv)
 	emscripten_set_main_loop(emscripten_main_loop, 0, 0);
 #endif
 	if (!headless) {
-		SDL_Init(SDL_INIT_VIDEO | SDL_INIT_EVENTS | SDL_INIT_GAMECONTROLLER | SDL_INIT_AUDIO);
+		SDL_Init(SDL_INIT_VIDEO | SDL_INIT_EVENTS | SDL_INIT_GAMECONTROLLER | SDL_INIT_AUDIO | SDL_INIT_TIMER);
 		audio_init(audio_dev_name, audio_buffers);
 		video_init(window_scale, screen_x_scale, scale_quality, fullscreen, window_opacity);
 	}

--- a/src/main.c
+++ b/src/main.c
@@ -1247,7 +1247,7 @@ handle_ieee_intercept()
 	if (handled) {
 		// Add the number CPU cycles equivalent to the amount of time that the operation actually took
 		// to prevent the emu from warping after a hostfs load
-		clockticks6502 += (uint64_t)((SDL_GetPerformanceCounter() - base_ticks) * 1000000 * MHZ) / SDL_GetPerformanceFrequency();
+		clockticks6502 += (uint64_t)((SDL_GetPerformanceCounter() - base_ticks) * 1000000ULL * MHZ) / SDL_GetPerformanceFrequency();
 		if (s >= 0) {
 			if (!set_kernal_status(s)) {
 				printf("Warning: Could not set STATUS!\n");

--- a/src/main.c
+++ b/src/main.c
@@ -1247,7 +1247,11 @@ handle_ieee_intercept()
 	if (handled) {
 		// Add the number CPU cycles equivalent to the amount of time that the operation actually took
 		// to prevent the emu from warping after a hostfs load
-		clockticks6502 += (uint64_t)((SDL_GetPerformanceCounter() - base_ticks) * 1000000ULL * MHZ) / SDL_GetPerformanceFrequency();
+		uint32_t missed_ticks = (uint64_t)((SDL_GetPerformanceCounter() - base_ticks) * 1000000ULL * MHZ) / SDL_GetPerformanceFrequency();
+		clockticks6502 += missed_ticks;
+		if (missed_ticks > 13333) {
+			printf("HostFS: missed ticks: %d\n", missed_ticks);
+		}
 		if (s >= 0) {
 			if (!set_kernal_status(s)) {
 				printf("Warning: Could not set STATUS!\n");


### PR DESCRIPTION
When doing large loads while sound is playing on HostFS, the buffer can easily underrun by default so we increase the default abufs.