### PR TITLE
Avoid invalid arguments to ctype(3) functions that may lead to undefined behavior.

### DIFF
--- a/src/cartridge.c
+++ b/src/cartridge.c
@@ -30,7 +30,7 @@ static int
 x16_strnicmp(char const *s0, char const *s1, int len)
 {
 	for(int i=0; (i<len) && (*s0 && *s1); ++i) {
-		if(tolower(*s0) != tolower(*s1)) {
+		if(tolower((unsigned char)*s0) != tolower((unsigned char)*s1)) {
 			break;
 		}
 		++s0;
@@ -216,7 +216,7 @@ static char *
 rtrim(char *str)
 {
     char *c = str + strlen(str) - 1;
-    while(isspace(*c)) {
+    while(isspace((unsigned char)*c)) {
 		--c;
 	}
     *(c + 1) = '\0';

--- a/src/rendertext.c
+++ b/src/rendertext.c
@@ -23,7 +23,7 @@ int textureInitialized = 0;
 //
 char *ltrim(char *s)
 {
-	while(isspace(*s)) s++;
+	while(isspace((unsigned char)*s)) s++;
 	return s;
 }
 


### PR DESCRIPTION
Cast "char" arguments to ctype(3) functions to "unsigned char" to avoid undefined behavior for negative char values.

Closes #203
