### PR TITLE
Add new command line switch -nokeyboardcapture as a less comprehensive capture mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ When starting `x16emu` without arguments, it will pick up the system ROM (`rom.b
 * `-keymap` tells the KERNAL to switch to a specific keyboard layout. Use it without an argument to view the supported layouts.
 * `-noemucmdkeys`  Disable emulator command keys. `Ctrl+M`/`⇧⌘M` will always be intercepted by the emulator.
 * `-capture` starts the emulator with the mouse/keyboard captured
+* `-nokeyboardcapture` prevents the emulator from fully capturing the keyboard in capture mode, which allows OS-level keystrokes like Alt+Tab to work while in capture mode.
 * `-sdcard` lets you specify an SD card image (partition table + FAT32) which will be presented as device 8 at boot.
 * `-hostfsdev <unit>` specifies the device number to use for the HostFS device. If this argument is not used, and `-sdcard` is specified, HostFS is disabled. If `-sdcard` is not specified, the default is 8. If both `-sdcard` and `-hostfsdev 8` are specified, HostFS will take precedence, but both will be active. In this circumstance, if the HostFS device is changed away from unit 8 via a channel 15 command (e.g. `"S-9"`), the SD card device will then become visible on unit 8.
 * `-fsroot <dir>` specifies a file system root for the HostFS interface. This lets you save and load files without an SD card image. (As of R42, this is the preferred method.) Default is the current working directory.

--- a/src/glue.h
+++ b/src/glue.h
@@ -98,6 +98,7 @@ extern uint8_t nvram[0x40];
 extern uint8_t MHZ;
 
 extern bool mouse_grabbed;
+extern bool no_keyboard_capture;
 extern bool kernal_mouse_enabled;
 extern char window_title[];
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -388,6 +388,10 @@ usage()
 	printf("\tDisable emulator command keys.\n");
 	printf("-capture\n");
 	printf("\tStart emulator with mouse/keyboard captured.\n");
+	printf("-nokeyboardcapture\n");
+	printf("\tWhile in capture mode, causes the emulator not to intercept\n");
+	printf("\tkeyboard combinations which are used by the operating system,\n");
+	printf("\tsuch as Alt+Tab.\n");
 	printf("-prg <app.prg>[,<load_addr>]\n");
 	printf("\tLoad application from the *host filesystem* into RAM,\n");
 	printf("\teven if an SD card is attached.\n");
@@ -927,6 +931,10 @@ main(int argc, char **argv)
 			argc--;
 			argv++;
 			grab_mouse = true;
+		} else if (!strcmp(argv[0], "-nokeyboardcapture")) {
+			argc--;
+			argv++;
+			no_keyboard_capture = true;
 		} else if (!strcmp(argv[0], "-via2")) {
 			argc--;
 			argv++;

--- a/src/video.c
+++ b/src/video.c
@@ -88,6 +88,7 @@ static SDL_Renderer *renderer;
 static SDL_Texture *sdlTexture;
 static bool is_fullscreen = false;
 bool mouse_grabbed = false;
+bool no_keyboard_capture = false;
 bool kernal_mouse_enabled = false;
 
 static uint8_t video_ram[0x20000];
@@ -204,7 +205,7 @@ static void refresh_palette();
 void
 mousegrab_toggle() {
 	mouse_grabbed = !mouse_grabbed;
-	SDL_SetWindowGrab(window, mouse_grabbed);
+	SDL_SetWindowGrab(window, mouse_grabbed && !no_keyboard_capture);
 	SDL_SetRelativeMouseMode(mouse_grabbed);
 	SDL_ShowCursor((mouse_grabbed || kernal_mouse_enabled) ? SDL_DISABLE : SDL_ENABLE);
 	sprintf(window_title, WINDOW_TITLE "%s", mouse_grabbed ? MOUSE_GRAB_MSG : "");


### PR DESCRIPTION
The default capture mode intercepts as many keyboard combinations as is allowed by the OS.  This new command line switch `-nokeyboardcapture` prevents the emulator from capturing OS level keys like Alt+Tab and friends.