### PR TITLE
Fix NMI vector addresses and RTI stack popping logic

### DIFF
--- a/src/cpu/fake6502.c
+++ b/src/cpu/fake6502.c
@@ -184,9 +184,9 @@ void nmi6502() {
     vp6502();
 
     if (regs.e) {
-        regs.pc = (uint16_t)read6502(0xFFFE) | ((uint16_t)read6502(0xFFFF) << 8);
+        regs.pc = (uint16_t)read6502(0xFFFA) | ((uint16_t)read6502(0xFFFB) << 8);
     } else {
-        regs.pc = (uint16_t)read6502(0xFFEE) | ((uint16_t)read6502(0xFFEF) << 8);
+        regs.pc = (uint16_t)read6502(0xFFEA) | ((uint16_t)read6502(0xFFEB) << 8);
     }
 
     clockticks6502 += 7; // consumed by CPU to process interrupt

--- a/src/cpu/instructions.h
+++ b/src/cpu/instructions.h
@@ -530,11 +530,10 @@ static void rti() {
     value = pull16();
     regs.pc = value;
 
-    if (!regs.e) {
-        regs.k = pull8();
+    if (regs.e) {
         regs.status |= FLAG_INDEX_WIDTH | FLAG_MEMORY_WIDTH;
-        regs.xh = 0;
-        regs.yh = 0;
+    } else {
+        regs.k = pull8();
     }
 }
 


### PR DESCRIPTION
- NMI was accidentally using the IRQ vectors.
- RTI's stack popping logic wasn't correct - it shouldn't force M and X to 1 in native mode.