### PR TITLE
Interrupt and stack overflow fixes

### DIFF
--- a/src/cpu/fake6502.c
+++ b/src/cpu/fake6502.c
@@ -164,49 +164,13 @@ static void putvalue(uint16_t saveval, bool use16Bit) {
 #include "tables.h"
 
 void nmi6502() {
-    if (!regs.e) {
-        push8(regs.k);
-    }
-
-    regs.k = 0; // also in emulated mode
-
-    push16(regs.pc);
-    push8(regs.e ? regs.status & ~FLAG_BREAK : regs.status);
-    setinterrupt();
-    cleardecimal();
-    vp6502();
-
-    if (regs.e) {
-        regs.pc = (uint16_t)read6502(0xFFFA) | ((uint16_t)read6502(0xFFFB) << 8);
-    } else {
-        regs.pc = (uint16_t)read6502(0xFFEA) | ((uint16_t)read6502(0xFFEB) << 8);
-    }
-
-    clockticks6502 += 7; // consumed by CPU to process interrupt
+    interrupt6502(INT_NMI);
     waiting = 0;
 }
 
 void irq6502() {
     if (!(regs.status & FLAG_INTERRUPT)) {
-        if (!regs.e) {
-            push8(regs.k);
-        }
-
-        regs.k = 0; // also in emulated mode
-
-        push16(regs.pc);
-        push8(regs.e ? regs.status & ~FLAG_BREAK : regs.status);
-        setinterrupt();
-        cleardecimal();
-        vp6502();
-
-        if (regs.e) {
-            regs.pc = (uint16_t)read6502(0xFFFE) | ((uint16_t)read6502(0xFFFF) << 8);
-        } else {
-            regs.pc = (uint16_t)read6502(0xFFEE) | ((uint16_t)read6502(0xFFEF) << 8);
-        }
-
-        clockticks6502 += 7; // consumed by CPU to process interrupt
+        interrupt6502(INT_IRQ);
     }
     waiting = 0;
 }

--- a/src/cpu/fake6502.c
+++ b/src/cpu/fake6502.c
@@ -168,6 +168,8 @@ void nmi6502() {
         push8(regs.k);
     }
 
+    regs.k = 0; // also in emulated mode
+
     push16(regs.pc);
     push8(regs.e ? regs.status & ~FLAG_BREAK : regs.status);
     setinterrupt();
@@ -189,6 +191,8 @@ void irq6502() {
         if (!regs.e) {
             push8(regs.k);
         }
+
+        regs.k = 0; // also in emulated mode
 
         push16(regs.pc);
         push8(regs.e ? regs.status & ~FLAG_BREAK : regs.status);

--- a/src/cpu/instructions.h
+++ b/src/cpu/instructions.h
@@ -164,21 +164,7 @@ static void brk() {
     penaltye = 1;
     regs.pc++;
 
-    if (!regs.e) {
-        push8(regs.k);
-    }
-
-    push16(regs.pc); //push next instruction address onto stack
-    push8(regs.status | (regs.e ? FLAG_BREAK : 0)); //push CPU status to stack
-    setinterrupt(); //set interrupt flag
-    cleardecimal();       // clear decimal flag (65C02 change)
-    vp6502();
-
-    if (regs.e) {
-        regs.pc = (uint16_t)read6502(0xFFFE) | ((uint16_t)read6502(0xFFFF) << 8);
-    } else {
-        regs.pc = (uint16_t)read6502(0xFFE6) | ((uint16_t)read6502(0xFFE7) << 8);
-    }
+    interrupt6502(INT_BRK);
 }
 
 static void bvc() {
@@ -230,21 +216,7 @@ static void cop() {
     penaltye = 1;
     regs.pc++;
 
-    if (!regs.e) {
-        push8(regs.k);
-    }
-
-    push16(regs.pc); //push next instruction address onto stack
-    push8(regs.status | FLAG_BREAK); //push CPU status to stack
-    setinterrupt(); //set interrupt flag
-    cleardecimal();       // clear decimal flag (65C02 change)
-    vp6502();
-
-    if (regs.e) {
-        regs.pc = (uint16_t)read6502(0xFFF4) | ((uint16_t)read6502(0xFFF5) << 8);
-    } else {
-        regs.pc = (uint16_t)read6502(0xFFE4) | ((uint16_t)read6502(0xFFE5) << 8);
-    }
+    interrupt6502(INT_COP);
 }
 
 static void cpx() {

--- a/src/cpu/support.h
+++ b/src/cpu/support.h
@@ -66,7 +66,7 @@
 
 uint16_t add_wrap_at_page_boundary(uint16_t value, uint8_t add) {
     if (regs.e) {
-        return (value & 0xFF00) | ((uint16_t) ((uint8_t) (value & 0x00FF)) + add);
+        return (value & 0xFF00) | ((uint16_t) (((uint8_t) (value & 0x00FF)) + add) & 0x00FF);
     } else {
         return value + add;
     }
@@ -74,7 +74,7 @@ uint16_t add_wrap_at_page_boundary(uint16_t value, uint8_t add) {
 
 uint16_t subtract_wrap_at_page_boundary(uint16_t value, uint8_t subtract) {
     if (regs.e) {
-        return (value & 0xFF00) | ((uint16_t) ((uint8_t) (value & 0x00FF)) - subtract);
+        return (value & 0xFF00) | ((uint16_t) (((uint8_t) (value & 0x00FF)) - subtract) & 0x00FF);
     } else {
         return value - subtract;
     }
@@ -82,7 +82,7 @@ uint16_t subtract_wrap_at_page_boundary(uint16_t value, uint8_t subtract) {
 
 void increment_wrap_at_page_boundary(uint16_t *value) {
     if (regs.e) {
-        *value = (*value & 0xFF00) | ((uint16_t) ((uint8_t) (*value & 0x00FF)) + 1);
+        *value = (*value & 0xFF00) | ((uint16_t) (((uint8_t) (*value & 0x00FF)) + 1) & 0x00FF);
     } else {
         (*value)++;
     }
@@ -90,7 +90,7 @@ void increment_wrap_at_page_boundary(uint16_t *value) {
 
 void decrement_wrap_at_page_boundary(uint16_t *value) {
     if (regs.e) {
-        *value = (*value & 0xFF00) | ((uint16_t) ((uint8_t) (*value & 0x00FF)) - 1);
+        *value = (*value & 0xFF00) | ((uint16_t) (((uint8_t) (*value & 0x00FF)) - 1) & 0x00FF);
     } else {
         (*value)--;
     }


### PR DESCRIPTION
- Set K to 0 on interrupts (even in emulated mode, the CPU just doesn't push the register value to the stack)
- Fix an error in the stack wraparound calculation that caused decrementing $0100 to result in $FFFF
- Refactor all interrupts into a shared function to avoid bugs due duplicated code.