### PR TITLE
More 65C816 changes

### DIFF
--- a/src/cpu/6502.opcodes
+++ b/src/cpu/6502.opcodes
@@ -42,7 +42,7 @@ bpl rel  2 $10
 bvc rel  2 $50
 bvs rel  2 $70
 
-brk imp  7 $00
+brk imp8 7 $00
 
 bit abso 4 $2c
 bit zp   3 $24

--- a/src/cpu/65c02.h
+++ b/src/cpu/65c02.h
@@ -25,7 +25,7 @@
 static void ainx() { 		// absolute indexed branch
     uint16_t eahelp, eahelp2;
     eahelp = (uint16_t)read6502(regs.pc) | (uint16_t)((uint16_t)read6502(regs.pc+1) << 8);
-    eahelp = (eahelp + regs.xw) & 0xFFFF;
+    eahelp = (eahelp + regs.x) & 0xFFFF;
 #if 0
     eahelp2 = (eahelp & 0xFF00) | ((eahelp + 1) & 0x00FF); //replicate 6502 page-boundary wraparound bug
 #else
@@ -67,9 +67,9 @@ static void phx() {
     penaltym = 1;
 
     if (index_16bit()) {
-        push16(regs.xw);
+        push16(regs.x);
     } else {
-        push8(regs.x);
+        push8(regs.xl);
     }
 }
 
@@ -77,24 +77,24 @@ static void plx() {
     penaltym = 1;
 
     if (index_16bit()) {
-        regs.xw = pull16();
-        zerocalc(regs.xw, 1);
-        signcalc(regs.xw, 1);
+        regs.x = pull16();
+        zerocalc(regs.x, 1);
+        signcalc(regs.x, 1);
     } else {
-        regs.x = pull8();
+        regs.xl = pull8();
     }
 
-    zerocalc(regs.x, 0);
-    signcalc(regs.x, 0);
+    zerocalc(regs.xl, 0);
+    signcalc(regs.xl, 0);
 }
 
 static void phy() {
     penaltym = 1;
 
     if (index_16bit()) {
-        push16(regs.yw);
+        push16(regs.y);
     } else {
-        push8(regs.y);
+        push8(regs.yl);
     }
 }
 
@@ -102,14 +102,14 @@ static void ply() {
     penaltym = 1;
 
     if (index_16bit()) {
-        regs.yw = pull16();
-        zerocalc(regs.yw, 1);
-        signcalc(regs.yw, 1);
+        regs.y = pull16();
+        zerocalc(regs.y, 1);
+        signcalc(regs.y, 1);
     } else {
-        regs.y = pull8();
+        regs.yl = pull8();
 
-        zerocalc(regs.x, 0);
-        signcalc(regs.x, 0);
+        zerocalc(regs.xl, 0);
+        signcalc(regs.xl, 0);
     }
 }
 

--- a/src/cpu/65c02.h
+++ b/src/cpu/65c02.h
@@ -82,10 +82,10 @@ static void plx() {
         signcalc(regs.x, 1);
     } else {
         regs.xl = pull8();
-    }
 
-    zerocalc(regs.xl, 0);
-    signcalc(regs.xl, 0);
+        zerocalc(regs.xl, 0);
+        signcalc(regs.xl, 0);
+    }
 }
 
 static void phy() {

--- a/src/cpu/65c816.opcodes
+++ b/src/cpu/65c816.opcodes
@@ -76,7 +76,7 @@ bit immm 2 $89
 bit zpx 4 $34
 bit absx 4 $3c
 
-cop imp 7 $02
+cop imp8 7 $02
 
 dec acc 2 $3a
 inc acc 2 $1a

--- a/src/cpu/buildtables.py
+++ b/src/cpu/buildtables.py
@@ -146,6 +146,7 @@ def generateList(hFileName, header, elements):
 def convertMnemonic(opInfo):
     modeStr = {
         "imp": "",
+        "imp8": "#$%02x",
         "imm8": "#$%02x",
         "immm": "#$%%0%hhux",
         "immx": "#$%%0%hhux",

--- a/src/cpu/instructions.h
+++ b/src/cpu/instructions.h
@@ -223,16 +223,16 @@ static void cpx() {
     value = getvalue(index_16bit());
 
     if (index_16bit()) {
-        result = regs.xw - value;
-        if(regs.xw >= value) setcarry();
+        result = regs.x - value;
+        if(regs.x >= value) setcarry();
         else clearcarry();
-        if (regs.xw == value) setzero();
+        if (regs.x == value) setzero();
         else clearzero();
     } else {
-        result = (uint16_t)regs.x - value;
-        if (regs.x >= (uint8_t)(value & 0x00FF)) setcarry();
+        result = (uint16_t)regs.xl - value;
+        if (regs.xl >= (uint8_t)(value & 0x00FF)) setcarry();
         else clearcarry();
-        if (regs.x == (uint8_t)(value & 0x00FF)) setzero();
+        if (regs.xl == (uint8_t)(value & 0x00FF)) setzero();
         else clearzero();
     }
     signcalc(result, index_16bit());
@@ -242,16 +242,16 @@ static void cpy() {
     value = getvalue(index_16bit());
 
     if (index_16bit()) {
-        result = regs.yw - value;
-        if(regs.yw >= value) setcarry();
+        result = regs.y - value;
+        if(regs.y >= value) setcarry();
         else clearcarry();
-        if (regs.yw == value) setzero();
+        if (regs.y == value) setzero();
         else clearzero();
     } else {
-        result = (uint16_t)regs.y - value;
-        if (regs.y >= (uint8_t)(value & 0x00FF)) setcarry();
+        result = (uint16_t)regs.yl - value;
+        if (regs.yl >= (uint8_t)(value & 0x00FF)) setcarry();
         else clearcarry();
-        if (regs.y == (uint8_t)(value & 0x00FF)) setzero();
+        if (regs.yl == (uint8_t)(value & 0x00FF)) setzero();
         else clearzero();
     }
     signcalc(result, index_16bit());
@@ -269,25 +269,25 @@ static void dec() {
 
 static void dex() {
     if (index_16bit()) {
-        regs.xw--;
-        zerocalc(regs.xw, 1);
-        signcalc(regs.xw, 1);
-    } else {
         regs.x--;
-        zerocalc(regs.x, 0);
-        signcalc(regs.x, 0);
+        zerocalc(regs.x, 1);
+        signcalc(regs.x, 1);
+    } else {
+        regs.xl--;
+        zerocalc(regs.xl, 0);
+        signcalc(regs.xl, 0);
     }
 }
 
 static void dey() {
     if (index_16bit()) {
-        regs.yw--;
-        zerocalc(regs.yw, 1);
-        signcalc(regs.yw, 1);
-    } else {
         regs.y--;
-        zerocalc(regs.y, 0);
-        signcalc(regs.y, 0);
+        zerocalc(regs.y, 1);
+        signcalc(regs.y, 1);
+    } else {
+        regs.yl--;
+        zerocalc(regs.yl, 0);
+        signcalc(regs.yl, 0);
     }
 }
 
@@ -314,25 +314,25 @@ static void inc() {
 
 static void inx() {
     if (index_16bit()) {
-        regs.xw++;
-        zerocalc(regs.xw, 1);
-        signcalc(regs.xw, 1);
-    } else {
         regs.x++;
-        zerocalc(regs.x, 0);
-        signcalc(regs.x, 0);
+        zerocalc(regs.x, 1);
+        signcalc(regs.x, 1);
+    } else {
+        regs.xl++;
+        zerocalc(regs.xl, 0);
+        signcalc(regs.xl, 0);
     }
 }
 
 static void iny() {
     if (index_16bit()) {
-        regs.yw++;
-        zerocalc(regs.yw, 1);
-        signcalc(regs.yw, 1);
-    } else {
         regs.y++;
-        zerocalc(regs.y, 0);
-        signcalc(regs.y, 0);
+        zerocalc(regs.y, 1);
+        signcalc(regs.y, 1);
+    } else {
+        regs.yl++;
+        zerocalc(regs.yl, 0);
+        signcalc(regs.yl, 0);
     }
 }
 
@@ -378,14 +378,14 @@ static void ldx() {
     penaltyx = 1;
 
     if (index_16bit()) {
-        regs.xw = getvalue(1);
-        zerocalc(regs.xw, 1);
-        signcalc(regs.xw, 1);
+        regs.x = getvalue(1);
+        zerocalc(regs.x, 1);
+        signcalc(regs.x, 1);
     } else {
         value = getvalue(0);
-        regs.x = (uint8_t)(value & 0x00FF);
-        zerocalc(regs.x, 0);
-        signcalc(regs.x, 0);
+        regs.xl = (uint8_t)(value & 0x00FF);
+        zerocalc(regs.xl, 0);
+        signcalc(regs.xl, 0);
     }
 }
 
@@ -394,13 +394,13 @@ static void ldy() {
     penaltyx = 1;
 
     if (index_16bit()) {
-        regs.yw = getvalue(1);
-        zerocalc(regs.yw, 1);
-        signcalc(regs.yw, 1);
+        regs.y = getvalue(1);
+        zerocalc(regs.y, 1);
+        signcalc(regs.y, 1);
     } else {
-        regs.y = (uint8_t)(getvalue(0) & 0x00FF);
-        zerocalc(regs.y, 0);
-        signcalc(regs.y, 0);
+        regs.yl = (uint8_t)(getvalue(0) & 0x00FF);
+        zerocalc(regs.yl, 0);
+        signcalc(regs.yl, 0);
     }
 }
 
@@ -681,34 +681,34 @@ static void sta() {
 }
 
 static void stx() {
-    putvalue(index_16bit() ? regs.xw : regs.x, index_16bit());
+    putvalue(index_16bit() ? regs.x : regs.xl, index_16bit());
 }
 
 static void sty() {
-    putvalue(index_16bit() ? regs.yw : regs.y, index_16bit());
+    putvalue(index_16bit() ? regs.y : regs.yl, index_16bit());
 }
 
 static void tax() {
     if (index_16bit()) {
-        regs.xw = regs.c; // 16 bits transferred, no matter the state of m
-        zerocalc(regs.xw, 1);
-        signcalc(regs.xw, 1);
+        regs.x = regs.c; // 16 bits transferred, no matter the state of m
+        zerocalc(regs.x, 1);
+        signcalc(regs.x, 1);
     } else {
-        regs.x = (uint8_t)(regs.a & 0x00FF);
-        zerocalc(regs.x, 0);
-        signcalc(regs.x, 0);
+        regs.xl = (uint8_t)(regs.a & 0x00FF);
+        zerocalc(regs.xl, 0);
+        signcalc(regs.xl, 0);
     }
 }
 
 static void tay() {
     if (index_16bit()) {
-        regs.yw = regs.c; // 16 bits transferred, no matter the state of m
-        zerocalc(regs.yw, 1);
-        signcalc(regs.yw, 1);
+        regs.y = regs.c; // 16 bits transferred, no matter the state of m
+        zerocalc(regs.y, 1);
+        signcalc(regs.y, 1);
     } else {
-        regs.y = (uint8_t)(regs.a & 0x00FF);
-        zerocalc(regs.y, 0);
-        signcalc(regs.y, 0);
+        regs.yl = (uint8_t)(regs.a & 0x00FF);
+        zerocalc(regs.yl, 0);
+        signcalc(regs.yl, 0);
     }
 }
 
@@ -726,31 +726,31 @@ static void tdc() {
 
 static void tsx() {
     if (index_16bit()) {
-        regs.xw = regs.sp; // 16 bits transferred, no matter the state of m
-        zerocalc(regs.xw, 1);
-        signcalc(regs.xw, 1);
+        regs.x = regs.sp; // 16 bits transferred, no matter the state of m
+        zerocalc(regs.x, 1);
+        signcalc(regs.x, 1);
     } else {
-        regs.x = (uint8_t)(regs.sp & 0x00FF);
+        regs.xl = (uint8_t)(regs.sp & 0x00FF);
         regs.xh = 0;
-        zerocalc(regs.x, 0);
-        signcalc(regs.x, 0);
+        zerocalc(regs.xl, 0);
+        signcalc(regs.xl, 0);
     }
 }
 
 static void txa() {
     if (memory_16bit()) {
         if (index_16bit()) {
-            regs.c = regs.xw;
+            regs.c = regs.x;
             zerocalc(regs.c, 1);
             signcalc(regs.c, 1);
         } else {
-            regs.a = regs.x;
+            regs.a = regs.xl;
             regs.b = 0;
             zerocalc(regs.a, 0);
             signcalc(regs.a, 0);
         }
     } else {
-        regs.a = regs.x;
+        regs.a = regs.xl;
         zerocalc(regs.a, 0);
         signcalc(regs.a, 0);
     }
@@ -758,38 +758,38 @@ static void txa() {
 
 static void txs() {
     if (regs.e) {
-        regs.sp = 0x100 | regs.x;
+        regs.sp = 0x100 | regs.xl;
     } else {
-        regs.sp = regs.xw;
+        regs.sp = regs.x;
     }
 }
 
 static void txy() {
     if (index_16bit()) {
-        regs.yw = regs.xw;
-        zerocalc(regs.yw, 1);
-        signcalc(regs.yw, 1);
-    } else {
         regs.y = regs.x;
-        zerocalc(regs.y, 0);
-        signcalc(regs.y, 0);
+        zerocalc(regs.y, 1);
+        signcalc(regs.y, 1);
+    } else {
+        regs.yl = regs.xl;
+        zerocalc(regs.yl, 0);
+        signcalc(regs.yl, 0);
     }
 }
 
 static void tya() {
     if (memory_16bit()) {
         if (index_16bit()) {
-            regs.c = regs.yw;
+            regs.c = regs.y;
             zerocalc(regs.c, 1);
             signcalc(regs.c, 1);
         } else {
-            regs.a = regs.y;
+            regs.a = regs.yl;
             regs.b = 0;
             zerocalc(regs.a, 0);
             signcalc(regs.a, 0);
         }
     } else {
-        regs.a = regs.y;
+        regs.a = regs.yl;
         zerocalc(regs.a, 0);
         signcalc(regs.a, 0);
     }
@@ -797,13 +797,13 @@ static void tya() {
 
 static void tyx() {
     if (index_16bit()) {
-        regs.xw = regs.yw;
-        zerocalc(regs.xw, 1);
-        signcalc(regs.xw, 1);
-    } else {
         regs.x = regs.y;
-        zerocalc(regs.x, 0);
-        signcalc(regs.x, 0);
+        zerocalc(regs.x, 1);
+        signcalc(regs.x, 1);
+    } else {
+        regs.xl = regs.yl;
+        zerocalc(regs.xl, 0);
+        signcalc(regs.xl, 0);
     }
 }
 
@@ -820,9 +820,9 @@ static void tsc() {
 static void mvn() {
     if (regs.c != 0xFFFF) {
         if (index_16bit()) {
-            write6502(regs.yw++, read6502(regs.xw++));
-        } else {
             write6502(regs.y++, read6502(regs.x++));
+        } else {
+            write6502(regs.yl++, read6502(regs.xl++));
         }
 
         regs.c--;
@@ -833,9 +833,9 @@ static void mvn() {
 static void mvp() {
     if (regs.c != 0xFFFF) {
         if (index_16bit()) {
-            write6502(regs.yw--, read6502(regs.xw--));
-        } else {
             write6502(regs.y--, read6502(regs.x--));
+        } else {
+            write6502(regs.yl--, read6502(regs.xl--));
         }
 
         regs.c--;

--- a/src/cpu/mnemonics.h
+++ b/src/cpu/mnemonics.h
@@ -2,7 +2,7 @@
 
 static const char *mnemonics_c02[256] = {
 	// $0X
-	/* $00 */ "brk ",
+	/* $00 */ "brk #$%02x",
 	/* $01 */ "ora ($%02x,x)",
 	/* $02 */ "nop #$%%0%hhux",
 	/* $03 */ "nop ",
@@ -291,9 +291,9 @@ static const char *mnemonics_c02[256] = {
 
 static const char *mnemonics_c816[256] = {
 	// $0X
-	/* $00 */ "brk ",
+	/* $00 */ "brk #$%02x",
 	/* $01 */ "ora ($%02x,x)",
-	/* $02 */ "cop ",
+	/* $02 */ "cop #$%02x",
 	/* $03 */ "ora $%02x,S",
 	/* $04 */ "tsb $%02x",
 	/* $05 */ "ora $%02x",

--- a/src/cpu/modes.h
+++ b/src/cpu/modes.h
@@ -58,11 +58,11 @@ static void zp() { //zero-page
 }
 
 static void zpx() { //zero-page,X
-    _zp_with_offset(regs.xw);
+    _zp_with_offset(regs.x);
 }
 
 static void zpy() { //zero-page,Y
-    _zp_with_offset(regs.yw);
+    _zp_with_offset(regs.y);
 }
 
 static void rel() { //relative for branch ops (8-bit immediate value, sign-extended)
@@ -84,7 +84,7 @@ static void absx() { //absolute,X
     uint16_t startpage;
     ea = ((uint16_t)read6502(regs.pc) | ((uint16_t)read6502(regs.pc+1) << 8));
     startpage = ea & 0xFF00;
-    ea += regs.xw;
+    ea += regs.x;
 
     if (startpage != (ea & 0xFF00)) { //one cycle penlty for page-crossing on some opcodes
         penaltyaddr = 1;
@@ -97,7 +97,7 @@ static void absy() { //absolute,Y
     uint16_t startpage;
     ea = ((uint16_t)read6502(regs.pc) | ((uint16_t)read6502(regs.pc+1) << 8));
     startpage = ea & 0xFF00;
-    ea += regs.yw;
+    ea += regs.y;
 
     if (startpage != (ea & 0xFF00)) { //one cycle penlty for page-crossing on some opcodes
         penaltyaddr = 1;
@@ -130,7 +130,7 @@ static void ind0() { // (zp)
 
 static void indx() { // (indirect,X)
     uint16_t eahelp;
-    eahelp = (uint16_t)read6502(regs.pc++) + regs.xw;
+    eahelp = (uint16_t)read6502(regs.pc++) + regs.x;
     ea = (uint16_t)read6502(direct_page_add(eahelp)) | ((uint16_t)read6502(direct_page_add(eahelp + 1)) << 8);
 
     if (regs.dp & 0x00FF) {
@@ -143,7 +143,7 @@ static void indy() { // (indirect),Y
     eahelp = (uint16_t)read6502(regs.pc++);
     ea = (uint16_t)read6502(direct_page_add(eahelp)) | ((uint16_t)read6502(direct_page_add(eahelp + 1)) << 8);
     startpage = ea & 0xFF00;
-    ea += regs.yw;
+    ea += regs.y;
 
     if (regs.dp & 0x00FF) {
         penaltyd = 1;
@@ -171,7 +171,7 @@ static void sridy() { // (indirect,S),Y
     eahelp = regs.sp + (uint16_t)read6502(regs.pc++);
     ea = (uint16_t)read6502(direct_page_add(eahelp)) | ((uint16_t)read6502(direct_page_add(eahelp + 1)) << 8);
     startpage = ea & 0xFF00;
-    ea += (uint16_t)regs.yw;
+    ea += (uint16_t)regs.y;
 
     if (startpage != (ea & 0xFF00)) { //one cycle penlty for page-crossing on some opcodes
         penaltyaddr = 1;

--- a/src/cpu/modes.h
+++ b/src/cpu/modes.h
@@ -15,6 +15,9 @@
 static void imp() { //implied
 }
 
+static void imp8() { // brk / cop
+}
+
 static void acc() { //accumulator
 }
 

--- a/src/cpu/registers.h
+++ b/src/cpu/registers.h
@@ -37,20 +37,20 @@ struct regs
     {
         struct
         {
-            uint8_t x;
+            uint8_t xl;
             uint8_t xh;
         };
-        uint16_t xw;
+        uint16_t x;
     };
 
     union
     {
         struct
         {
-            uint8_t y;
+            uint8_t yl;
             uint8_t yh;
         };
-        uint16_t yw;
+        uint16_t y;
     };
 
     uint16_t dp;

--- a/src/cpu/registers.h
+++ b/src/cpu/registers.h
@@ -20,38 +20,31 @@
 
 //6502 CPU registers
 
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#define LOW_HIGH_UNION(name, low, high) \
+    union { \
+        struct { \
+            uint8_t low; \
+            uint8_t high; \
+        }; \
+        uint16_t name; \
+    }
+#else
+#define LOW_HIGH_UNION(name, low, high) \
+    union { \
+        struct { \
+            uint8_t high; \
+            uint8_t low; \
+        }; \
+        uint16_t name; \
+    }
+#endif
+
 struct regs
 {
-    union
-    {
-        struct
-        {
-            uint8_t a;
-            uint8_t b;
-        };
-
-        uint16_t c;
-    };
-
-    union
-    {
-        struct
-        {
-            uint8_t xl;
-            uint8_t xh;
-        };
-        uint16_t x;
-    };
-
-    union
-    {
-        struct
-        {
-            uint8_t yl;
-            uint8_t yh;
-        };
-        uint16_t y;
-    };
+    LOW_HIGH_UNION(c, a, b);
+    LOW_HIGH_UNION(x, xl, xh);
+    LOW_HIGH_UNION(y, yl, yh);
 
     uint16_t dp;
     uint16_t sp;
@@ -65,6 +58,8 @@ struct regs
 
     bool is65c816;
 };
+
+#undef LOW_HIGH_UNION
 
 void increment_wrap_at_page_boundary(uint16_t *value);
 void decrement_wrap_at_page_boundary(uint16_t *value);

--- a/src/cpu/support.h
+++ b/src/cpu/support.h
@@ -136,8 +136,8 @@ uint8_t pull8() {
 void reset6502(bool c816) {
     regs.pc = (uint16_t)read6502(0xFFFC) | ((uint16_t)read6502(0xFFFD) << 8);
     regs.c = 0;
-    regs.xw = 0;
-    regs.yw = 0;
+    regs.x = 0;
+    regs.y = 0;
     regs.dp = 0;
     regs.sp = 0x1FD;
     regs.e = 1;

--- a/src/cpu/tables.h
+++ b/src/cpu/tables.h
@@ -2,7 +2,7 @@
 
 static void (*addrtable_c02[256])() = {
 /*        |  0  |  1  |  2  |  3  |  4  |  5  |  6  |  7  |  8  |  9  |  A  |  B  |  C  |  D  |  E  |  F  |     */
-/* 0 */     imp, indx, immm,  imp,   zp,   zp,   zp,   zp,  imp, immm,  acc,  imp, abso, abso, abso,zprel, /* 0 */
+/* 0 */    imp8, indx, immm,  imp,   zp,   zp,   zp,   zp,  imp, immm,  acc,  imp, abso, abso, abso,zprel, /* 0 */
 /* 1 */     rel, indy, ind0,  imp,   zp,  zpx,  zpx,   zp,  imp, absy,  acc,  imp, abso, absx, absx,zprel, /* 1 */
 /* 2 */    abso, indx, immm,  imp,   zp,   zp,   zp,   zp,  imp, immm,  acc,  imp, abso, abso, abso,zprel, /* 2 */
 /* 3 */     rel, indy, ind0,  imp,  zpx,  zpx,  zpx,   zp,  imp, absy,  acc,  imp, absx, absx, absx,zprel, /* 3 */
@@ -22,7 +22,7 @@ static void (*addrtable_c02[256])() = {
 
 static void (*addrtable_c816[256])() = {
 /*        |  0  |  1  |  2  |  3  |  4  |  5  |  6  |  7  |  8  |  9  |  A  |  B  |  C  |  D  |  E  |  F  |     */
-/* 0 */     imp, indx,  imp,   sr,   zp,   zp,   zp,indl0,  imp, immm,  acc,  imp, abso, abso, abso, absl, /* 0 */
+/* 0 */    imp8, indx, imp8,   sr,   zp,   zp,   zp,indl0,  imp, immm,  acc,  imp, abso, abso, abso, absl, /* 0 */
 /* 1 */     rel, indy, ind0,sridy,   zp,  zpx,  zpx,indly,  imp, absy,  acc,  imp, abso, absx, absx,abslx, /* 1 */
 /* 2 */    abso, indx, absl,   sr,   zp,   zp,   zp,indl0,  imp, immm,  acc,  imp, abso, abso, abso, absl, /* 2 */
 /* 3 */     rel, indy, ind0,sridy,  zpx,  zpx,  zpx,indly,  imp, absy,  acc,  imp, absx, absx, absx,abslx, /* 3 */

--- a/src/debugger.c
+++ b/src/debugger.c
@@ -680,7 +680,7 @@ static void DEBUGRenderCode(int lines, int initialPC) {
 //
 // *******************************************************************************************
 
-static char *labels_c816[] = { "NVMXDIZCE","","","A","B","C","XL","X","YL","Y","DB","K","","BKA","BKO", "PC","DP","SP","","BRK","", "VA","VD0","VD1","VCT", NULL };
+static char *labels_c816[] = { "NVMXDIZCE","","","A","B","C","X","Y","DB","K","","BKA","BKO", "PC","DP","SP","","BRK","", "VA","VD0","VD1","VCT", NULL };
 static char *labels_c02[] = { "NV-BDIZC","","","A","X","Y","","BKA","BKO", "PC","SP","","BRK","", "VA","VD0","VD1","VCT", NULL };
 
 static void DEBUGNumberHighByteCondition(int x, int y, int n, _Bool condition, SDL_Color ifTrue, SDL_Color ifFalse) {
@@ -715,9 +715,7 @@ static int DEBUGRenderRegisters(void) {
 		DEBUGNumber(DBG_DATX, yc++, regs.a, 2, col_data);
 		DEBUGNumber(DBG_DATX, yc++, regs.b, 2, col_data);
 		DEBUGNumber(DBG_DATX, yc++, regs.c, 4, col_data);
-		DEBUGNumber(DBG_DATX, yc++, regs.xl, 2, col_data);
 		DEBUGNumberHighByteCondition(DBG_DATX, yc++, regs.x, (regs.status >> 4) & 1, col_vram_other, col_data);
-		DEBUGNumber(DBG_DATX, yc++, regs.yl, 2, col_data);
 		DEBUGNumberHighByteCondition(DBG_DATX, yc++, regs.y, (regs.status >> 4) & 1, col_vram_other, col_data);
 		DEBUGNumber(DBG_DATX, yc++, regs.db, 2, col_data);
 		DEBUGNumber(DBG_DATX, yc++, regs.k, 2, col_data);

--- a/src/debugger.c
+++ b/src/debugger.c
@@ -493,16 +493,16 @@ static void DEBUGExecCmd() {
 			}
 			if(!strcmp(reg, "x")) {
 				if (regs.e) {
-					regs.x= number & 0x00FF;
+					regs.xl= number & 0x00FF;
 				} else {
-					regs.xw= number & 0xFFFF;
+					regs.x= number & 0xFFFF;
 				}
 			}
 			if(!strcmp(reg, "y")) {
 				if (regs.e) {
-					regs.y= number & 0x00FF;
+					regs.yl= number & 0x00FF;
 				} else {
-					regs.yw= number & 0xFFFF;
+					regs.y= number & 0xFFFF;
 				}
 			}
 			if(!strcmp(reg, "sp")) {
@@ -680,7 +680,7 @@ static void DEBUGRenderCode(int lines, int initialPC) {
 //
 // *******************************************************************************************
 
-static char *labels_c816[] = { "NVMXDIZCE","","","A","B","C","X","XW","Y","YW","DB","K","","BKA","BKO", "PC","DP","SP","","BRK","", "VA","VD0","VD1","VCT", NULL };
+static char *labels_c816[] = { "NVMXDIZCE","","","A","B","C","XL","X","YL","Y","DB","K","","BKA","BKO", "PC","DP","SP","","BRK","", "VA","VD0","VD1","VCT", NULL };
 static char *labels_c02[] = { "NV-BDIZC","","","A","X","Y","","BKA","BKO", "PC","SP","","BRK","", "VA","VD0","VD1","VCT", NULL };
 
 static void DEBUGNumberHighByteCondition(int x, int y, int n, _Bool condition, SDL_Color ifTrue, SDL_Color ifFalse) {
@@ -715,10 +715,10 @@ static int DEBUGRenderRegisters(void) {
 		DEBUGNumber(DBG_DATX, yc++, regs.a, 2, col_data);
 		DEBUGNumber(DBG_DATX, yc++, regs.b, 2, col_data);
 		DEBUGNumber(DBG_DATX, yc++, regs.c, 4, col_data);
-		DEBUGNumber(DBG_DATX, yc++, regs.x, 2, col_data);
-		DEBUGNumberHighByteCondition(DBG_DATX, yc++, regs.xw, (regs.status >> 4) & 1, col_vram_other, col_data);
-		DEBUGNumber(DBG_DATX, yc++, regs.y, 2, col_data);
-		DEBUGNumberHighByteCondition(DBG_DATX, yc++, regs.yw, (regs.status >> 4) & 1, col_vram_other, col_data);
+		DEBUGNumber(DBG_DATX, yc++, regs.xl, 2, col_data);
+		DEBUGNumberHighByteCondition(DBG_DATX, yc++, regs.x, (regs.status >> 4) & 1, col_vram_other, col_data);
+		DEBUGNumber(DBG_DATX, yc++, regs.yl, 2, col_data);
+		DEBUGNumberHighByteCondition(DBG_DATX, yc++, regs.y, (regs.status >> 4) & 1, col_vram_other, col_data);
 		DEBUGNumber(DBG_DATX, yc++, regs.db, 2, col_data);
 		DEBUGNumber(DBG_DATX, yc++, regs.k, 2, col_data);
 		yc++;
@@ -744,8 +744,8 @@ static int DEBUGRenderRegisters(void) {
 		yc+= 2;
 
 		DEBUGNumber(DBG_DATX, yc++, regs.a, 2, col_data);
-		DEBUGNumber(DBG_DATX, yc++, regs.x, 2, col_data);
-		DEBUGNumber(DBG_DATX, yc++, regs.y, 2, col_data);
+		DEBUGNumber(DBG_DATX, yc++, regs.xl, 2, col_data);
+		DEBUGNumber(DBG_DATX, yc++, regs.yl, 2, col_data);
 		yc++;
 
 		DEBUGNumber(DBG_DATX, yc++, memory_get_ram_bank(), 2, col_data);

--- a/src/disasm.c
+++ b/src/disasm.c
@@ -158,16 +158,16 @@ int disasm(uint16_t pc, uint8_t *RAM, char *line, unsigned int max_line, bool de
 				if (isIndirect) {
 					uint16_t ptr = real_read6502(pc + 1, debugOn, bank);
 					if (isXrel)
-						ptr += regs.xw;
+						ptr += regs.x;
 					*eff_addr = real_read6502(ptr, debugOn, bank) | (real_read6502(ptr + 1, debugOn, bank) << 8);
 					if (isYrel)
-						*eff_addr += regs.yw;
+						*eff_addr += regs.y;
 				} else if (!isImmediate) {
 					*eff_addr = real_read6502(pc + 1, debugOn, bank);
 					if (isXrel)
-						*eff_addr += regs.xw;
+						*eff_addr += regs.x;
 					if (isYrel)
-						*eff_addr += regs.yw;
+						*eff_addr += regs.y;
 				}
 			}
 		}
@@ -177,16 +177,16 @@ int disasm(uint16_t pc, uint8_t *RAM, char *line, unsigned int max_line, bool de
 			if (isIndirect) {
 				uint16_t ptr = real_read6502(pc + 1, debugOn, bank) | (real_read6502(pc + 2, debugOn, bank) << 8);
 				if (isXrel)
-					ptr += regs.xw;
+					ptr += regs.x;
 				*eff_addr = real_read6502(ptr, debugOn, bank) | (real_read6502(ptr + 1, debugOn, bank) << 8);
 				if (isYrel)
-					*eff_addr += regs.yw;
+					*eff_addr += regs.y;
 			} else {
 				*eff_addr = real_read6502(pc + 1, debugOn, bank) | (real_read6502(pc + 2, debugOn, bank) << 8);
 				if (isXrel)
-					*eff_addr += regs.xw;
+					*eff_addr += regs.x;
 				if (isYrel)
-					*eff_addr += regs.yw;
+					*eff_addr += regs.y;
 			}
 		}
 		if (strstr(line, "%06x")) {
@@ -195,16 +195,16 @@ int disasm(uint16_t pc, uint8_t *RAM, char *line, unsigned int max_line, bool de
 			if (isIndirect) {
 				uint16_t ptr = real_read6502(pc + 1, debugOn, bank) | (real_read6502(pc + 2, debugOn, bank) << 8);
 				if (isXrel)
-					ptr += regs.xw;
+					ptr += regs.x;
 				*eff_addr = real_read6502(ptr, debugOn, bank) | (real_read6502(ptr + 1, debugOn, bank) << 8);
 				if (isYrel)
-					*eff_addr += regs.yw;
+					*eff_addr += regs.y;
 			} else {
 				*eff_addr = real_read6502(pc + 1, debugOn, bank) | (real_read6502(pc + 2, debugOn, bank) << 8);
 				if (isXrel)
-					*eff_addr += regs.xw;
+					*eff_addr += regs.x;
 				if (isYrel)
-					*eff_addr += regs.yw;
+					*eff_addr += regs.y;
 			}
 		}
 		if (opcode == 0x00 || opcode == 0x02) {

--- a/src/disasm.c
+++ b/src/disasm.c
@@ -120,6 +120,10 @@ int disasm(uint16_t pc, uint8_t *RAM, char *line, unsigned int max_line, bool de
 	//      block move (MVN and MVP)
 	int isBlockMove = opcode == 0x44 || opcode == 0x54;
 
+	//
+	//      BRK and COP
+	int isBrkOrCop = opcode == 0x00 || opcode == 0x02;
+
 	int length   = 1;
 
 	char *where = strstr(mnemonic, "%%0%hhux");
@@ -148,6 +152,10 @@ int disasm(uint16_t pc, uint8_t *RAM, char *line, unsigned int max_line, bool de
 	else if (isRel16) {
 		snprintf(line, max_line, mnemonic, (pc + 3 + (int16_t)(real_read6502(pc + 1, debugOn, bank) | (real_read6502(pc + 2, debugOn, bank) << 8))) & 0xffff);
 		length = 3;
+	}
+	else if (isBrkOrCop) {
+		snprintf(line, max_line, mnemonic, real_read6502(pc + 1, debugOn, bank));
+		length = 2;
 	} else {
 		if (strstr(line, "%02x")) {
 			length = 2;

--- a/src/main.c
+++ b/src/main.c
@@ -1237,8 +1237,8 @@ handle_ieee_intercept()
 			} else if (s == -3) {
 				regs.status = (regs.status | 1); // SEC (unsupported, or in this case, no open context)
 			} else {
-				regs.xl = count & 0xff;
-				regs.yl = count >> 8;
+				regs.x = count & 0xff;
+				regs.y = count >> 8;
 				regs.status &= 0xfe; // clear C -> supported
 			}
 			break;
@@ -1251,8 +1251,8 @@ handle_ieee_intercept()
 			} else if (s == -3) {
 				regs.status = (regs.status | 1); // SEC (unsupported, or in this case, no open context)
 			} else {
-				regs.xl = count & 0xff;
-				regs.yl = count >> 8;
+				regs.x = count & 0xff;
+				regs.y = count >> 8;
 				regs.status &= 0xfe; // clear C -> supported
 			}
 			break;

--- a/src/main.c
+++ b/src/main.c
@@ -269,8 +269,8 @@ machine_dump(const char* reason)
 
 	if (dump_cpu) {
 		SDL_RWwrite(f, &regs.a, sizeof(uint8_t), 1);
-		SDL_RWwrite(f, &regs.x, sizeof(uint8_t), 1);
-		SDL_RWwrite(f, &regs.y, sizeof(uint8_t), 1);
+		SDL_RWwrite(f, &regs.xl, sizeof(uint8_t), 1);
+		SDL_RWwrite(f, &regs.yl, sizeof(uint8_t), 1);
 		SDL_RWwrite(f, &regs.sp, sizeof(uint8_t), 1);
 		SDL_RWwrite(f, &regs.status, sizeof(uint8_t), 1);
 		SDL_RWwrite(f, &regs.pc, sizeof(uint16_t), 1);
@@ -1231,28 +1231,28 @@ handle_ieee_intercept()
 	switch(regs.pc) {
 		case 0xFEB1: {
 			uint16_t count = regs.a;
-			s=MCIOUT(regs.y << 8 | regs.x, &count, regs.status & 0x01);
+			s=MCIOUT(regs.yl << 8 | regs.xl, &count, regs.status & 0x01);
 			if (s == -2) {
 				handled = false;
 			} else if (s == -3) {
 				regs.status = (regs.status | 1); // SEC (unsupported, or in this case, no open context)
 			} else {
-				regs.x = count & 0xff;
-				regs.y = count >> 8;
+				regs.xl = count & 0xff;
+				regs.yl = count >> 8;
 				regs.status &= 0xfe; // clear C -> supported
 			}
 			break;
 		}
 		case 0xFF44: {
 			uint16_t count = regs.a;
-			s=MACPTR(regs.y << 8 | regs.x, &count, regs.status & 0x01);
+			s=MACPTR(regs.yl << 8 | regs.xl, &count, regs.status & 0x01);
 			if (s == -2) {
 				handled = false;
 			} else if (s == -3) {
 				regs.status = (regs.status | 1); // SEC (unsupported, or in this case, no open context)
 			} else {
-				regs.x = count & 0xff;
-				regs.y = count >> 8;
+				regs.xl = count & 0xff;
+				regs.yl = count >> 8;
 				regs.status &= 0xfe; // clear C -> supported
 			}
 			break;
@@ -1442,7 +1442,7 @@ emulator_loop(void *param)
 				printf(" ");
 			}
 
-			printf("a=$%04x x=$%04x y=$%04x s=$%04x p=", regs.c, regs.xw, regs.yw, regs.sp);
+			printf("a=$%04x x=$%04x y=$%04x s=$%04x p=", regs.c, regs.x, regs.y, regs.sp);
 			for (int i = 7; i >= 0; i--) {
 				printf("%c", (regs.status & (1 << i)) ? "czidxmvn"[i] : '-');
 			}

--- a/src/testbench.c
+++ b/src/testbench.c
@@ -173,7 +173,7 @@ void testbench_init()
                 if (ival == -1) {
                     invalid();
                 } else {
-                    regs.xl = (uint8_t)ival;
+                    regs.x = (uint8_t)ival;
                     ready();
                 }
             }
@@ -188,7 +188,7 @@ void testbench_init()
                 if (ival == -1) {
                     invalid();
                 } else {
-                    regs.yl = (uint8_t)ival;
+                    regs.y = (uint8_t)ival;
                     ready();
                 }
             }

--- a/src/testbench.c
+++ b/src/testbench.c
@@ -173,7 +173,7 @@ void testbench_init()
                 if (ival == -1) {
                     invalid();
                 } else {
-                    regs.x = (uint8_t)ival;
+                    regs.xl = (uint8_t)ival;
                     ready();
                 }
             }
@@ -188,7 +188,7 @@ void testbench_init()
                 if (ival == -1) {
                     invalid();
                 } else {
-                    regs.y = (uint8_t)ival;
+                    regs.yl = (uint8_t)ival;
                     ready();
                 }
             }
@@ -266,12 +266,12 @@ void testbench_init()
         }
 
         else if(strncmp(line, "RQX", 3) == 0) {             //Request X register value
-            printf("%lx\n", (long)regs.x);
+            printf("%lx\n", (long)regs.xl);
             fflush(stdout);
         }
 
         else if(strncmp(line, "RQY", 3) == 0) {             //Request Y register value
-            printf("%lx\n", (long)regs.y);
+            printf("%lx\n", (long)regs.yl);
             fflush(stdout);
         }
 


### PR DESCRIPTION
- Rename `regs.x` to `regs.xl` and `regs.xw` to `regs.x`, same for `y`, and make those unions endianess-aware
- Remove debug display for the low bytes of X and Y
- Don't write to only `xl` while leaving `xh` intact as that's not possible on real hardware
- Fix flag calculation in `plx`
- Show the signature bytes for BRK and COP in the disassembler