### PR TITLE
Interrupt Fix and Debugger Display

### DIFF
--- a/src/cpu/support.h
+++ b/src/cpu/support.h
@@ -176,8 +176,12 @@ void interrupt6502(enum InterruptType vector) {
     push16(regs.pc);
 
     if (regs.e) {
-        push8(vector == INT_BRK ? regs.status | FLAG_BREAK : regs.status & ~FLAG_BREAK);
-        vector = INT_IRQ;
+        if (vector == INT_BRK) {
+            push8(regs.status | FLAG_BREAK);
+            vector = INT_IRQ;
+        } else {
+            push8(regs.status & ~FLAG_BREAK);
+        }
     } else {
         push8(regs.status);
     }

--- a/src/debugger.c
+++ b/src/debugger.c
@@ -787,9 +787,7 @@ static int DEBUGRenderRegisters(void) {
 		DEBUGNumber(DBG_LBLX+5, yc, (regs.status >> 2) & 1, 1, col_data);
 		DEBUGNumber(DBG_LBLX+6, yc, (regs.status >> 1) & 1, 1, col_data);
 		DEBUGNumber(DBG_LBLX+7, yc, (regs.status >> 0) & 1, 1, col_data);
-		if (regs.is65c816) {
-			DEBUGNumber(DBG_LBLX+8, yc, regs.e, 1, col_data);
-		}
+		DEBUGNumber(DBG_LBLX+8, yc, regs.e, 1, col_data);
 		yc+= 2;
 
 		DEBUGNumber(DBG_DATX, yc++, regs.a, 2, col_data);

--- a/src/debugger.c
+++ b/src/debugger.c
@@ -760,8 +760,8 @@ static void DEBUGRenderCode(int lines, int initialPC) {
 //
 // *******************************************************************************************
 
-static char *labels_c816[] = { "NVMXDIZCE","","","A","B","C","X","Y","DB","K","","BKA","BKO", "PC","DP","SP","","BRK", NULL };
-static char *labels_c02[] = { "NV-BDIZC","","","A","X","Y","","BKA","BKO", "PC","SP","","BRK", NULL };
+static char *labels_c816[] = { "NVMXDIZCE","","","A","B","C","X","Y","K","DB","","PC","DP","SP","BKA","BKO","","BRK", NULL };
+static char *labels_c02[] = { "NV-BDIZC","","","A","X","Y","","PC","SP","BKA","BKO","","BRK", NULL };
 
 static void DEBUGNumberHighByteCondition(int x, int y, int n, bool condition, SDL_Color ifTrue, SDL_Color ifFalse) {
 	if (condition) {
@@ -797,15 +797,15 @@ static int DEBUGRenderRegisters(void) {
 		DEBUGNumber(DBG_DATX, yc++, regs.c, 4, col_data);
 		DEBUGNumberHighByteCondition(DBG_DATX, yc++, regs.x, (regs.status >> 4) & 1, col_vram_other, col_data);
 		DEBUGNumberHighByteCondition(DBG_DATX, yc++, regs.y, (regs.status >> 4) & 1, col_vram_other, col_data);
-		DEBUGNumber(DBG_DATX, yc++, regs.db, 2, col_data);
 		DEBUGNumber(DBG_DATX, yc++, regs.k, 2, col_data);
+		DEBUGNumber(DBG_DATX, yc++, regs.db, 2, col_data);
 		yc++;
 
-		DEBUGNumber(DBG_DATX, yc++, memory_get_ram_bank(), 2, col_data);
-		DEBUGNumber(DBG_DATX, yc++, memory_get_rom_bank(), 2, col_data);
 		DEBUGNumber(DBG_DATX, yc++, regs.pc, 4, col_data);
 		DEBUGNumber(DBG_DATX, yc++, regs.dp, 4, col_data);
 		DEBUGNumberHighByteCondition(DBG_DATX, yc++, regs.sp, regs.e, col_vram_other, col_data);
+		DEBUGNumber(DBG_DATX, yc++, memory_get_ram_bank(), 2, col_data);
+		DEBUGNumber(DBG_DATX, yc++, memory_get_rom_bank(), 2, col_data);
 		yc++;
 	} else {
 		while (labels_c02[n] != NULL) {									// Labels
@@ -826,10 +826,10 @@ static int DEBUGRenderRegisters(void) {
 		DEBUGNumber(DBG_DATX, yc++, regs.yl, 2, col_data);
 		yc++;
 
-		DEBUGNumber(DBG_DATX, yc++, memory_get_ram_bank(), 2, col_data);
-		DEBUGNumber(DBG_DATX, yc++, memory_get_rom_bank(), 2, col_data);
 		DEBUGNumber(DBG_DATX, yc++, regs.pc, 4, col_data);
 		DEBUGNumber(DBG_DATX, yc++, regs.sp|0x100, 4, col_data);
+		DEBUGNumber(DBG_DATX, yc++, memory_get_ram_bank(), 2, col_data);
+		DEBUGNumber(DBG_DATX, yc++, memory_get_rom_bank(), 2, col_data);
 		yc++;
 
 	}


### PR DESCRIPTION
- The emulator no longer treats all non-BRK interrupts as IRQ in emulator mode. Emulated COP was not happy.
- Reordered some registers in the debugger view.
- Removed an unnecessary duplicate `if (regs.is65c816)`.