### PR TITLE
Support key int'l 1, needed at least for pt-BR layout

### DIFF
--- a/src/keyboard.c
+++ b/src/keyboard.c
@@ -226,6 +226,8 @@ keynum_from_SDL_Scancode(SDL_Scancode scancode)
 			return 95;
 		case SDL_SCANCODE_NUMLOCKCLEAR:
 			return 90;
+		case SDL_SCANCODE_INTERNATIONAL1:
+			return 56;
 		default:
 			return 0;
 	}

--- a/src/keyboard.c
+++ b/src/keyboard.c
@@ -11,8 +11,6 @@
 int
 keynum_from_SDL_Scancode(SDL_Scancode scancode)
 {
-	printf("key value: %u\n", scancode);
-	
 	switch (scancode) {
 		case SDL_SCANCODE_GRAVE:
 			return 1;

--- a/src/keyboard.c
+++ b/src/keyboard.c
@@ -11,6 +11,8 @@
 int
 keynum_from_SDL_Scancode(SDL_Scancode scancode)
 {
+	printf("key value: %u\n", scancode);
+	
 	switch (scancode) {
 		case SDL_SCANCODE_GRAVE:
 			return 1;


### PR DESCRIPTION
Adding support for the int'l 1 key, needed at least for pt-BR keyboard layout.