### PR TITLE
Added -longpwron option to emulator to simulate power on longpress.

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ When starting `x16emu` without arguments, it will pick up the system ROM (`rom.b
 * `-c02` selects the 65C02 CPU (default).
 * `-c816` selects the 65C816 CPU (experimental).
 * `-rockwell` when used while running with the 65C02 CPU, suppresses the console warning emitted on the first occurence when executing a Rockwell instruction. These are the SMBx, RMBx, BBRx, and BBSx instructions. Since these instructions are not supported on the 65C816 processor, such a program using them would not run properly on the 65C816.
+* `-longpwron` Simulate that the system has been powered on with a longpress on powerbutton.
 * When compiled with `#define TRACE`, `-trace` will enable an instruction trace on stdout.
 
 Run `x16emu -h` to see all command line options.

--- a/src/glue.h
+++ b/src/glue.h
@@ -103,4 +103,5 @@ extern bool mouse_grabbed;
 extern bool no_keyboard_capture;
 extern bool kernal_mouse_enabled;
 extern char window_title[];
+extern bool pwr_long_press;
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -495,7 +495,7 @@ usage()
 	printf("-rockwell\n");
 	printf("\tSuppress warning emitted when encountering a Rockwell extension on the 65C02\n");
 	printf("-longpwron\n");
-	printf("\tSimulate that the system has been powered on with a longpress on powerbuttn.\n");
+	printf("\tSimulate that the system has been powered on with a longpress on powerbutton.\n");
 #ifdef TRACE
 	printf("-trace [<address>]\n");
 	printf("\tPrint instruction trace. Optionally, a trigger address\n");

--- a/src/main.c
+++ b/src/main.c
@@ -146,6 +146,8 @@ bool run_after_load = false;
 
 char *nvram_path = NULL;
 
+bool pwr_long_press=false;
+
 #ifdef TRACE
 #include "rom_labels.h"
 #include "rom_lst.h"
@@ -492,6 +494,8 @@ usage()
 	printf("\tThis option is experimental.\n");
 	printf("-rockwell\n");
 	printf("\tSuppress warning emitted when encountering a Rockwell extension on the 65C02\n");
+	printf("-longpwron\n");
+	printf("\tSimulate that the system has been powered on with a longpress on powerbuttn.\n");
 #ifdef TRACE
 	printf("-trace [<address>]\n");
 	printf("\tPrint instruction trace. Optionally, a trigger address\n");
@@ -943,6 +947,10 @@ main(int argc, char **argv)
 			argc--;
 			argv++;
 			grab_mouse = true;
+		} else if (!strcmp(argv[0], "-longpwron")) {
+			argc--;
+			argv++;
+			pwr_long_press = true;
 		} else if (!strcmp(argv[0], "-nokeyboardcapture")) {
 			argc--;
 			argv++;

--- a/src/smc.c
+++ b/src/smc.c
@@ -34,7 +34,16 @@ smc_read(uint8_t a) {
 		// Offset that returns one byte from the keyboard buffer
 		case 7:
 			return i2c_kbd_buffer_next();
-
+		// Offset, initially used for debugging in the SMC, but now
+		// also used to inform kernal whether power on was done by
+		// holding the power button
+		case 9:
+			if (pwr_long_press) {
+				// Reset pwr_long_press so a reset will start normally
+				pwr_long_press = false;
+				return 1;
+			} else	return 0;
+			
 		// Offset that returns three bytes from mouse buffer (one movement packet) or a single zero if there is not complete packet in the buffer
 		// mse_count keeps track of which one of the three bytes it's sending
 		case 0x21:


### PR DESCRIPTION
This enables the emulator to simulate that it has been started by holding the power button pressed for a while. This in turn will allow the emulator to boot directly into the diag ROM bank.