### PR TITLE
Minor enahncements to TRACE output

### DIFF
--- a/src/disasm.c
+++ b/src/disasm.c
@@ -310,6 +310,7 @@ int disasm(uint16_t pc, uint8_t *RAM, char *line, unsigned int max_line, bool de
 	if (isBlockMove) {
 		snprintf(line, max_line, mnemonic, real_read6502(pc + 1, debugOn, bank), real_read6502(pc + 2, debugOn, bank));
 		length = 3;
+		*eff_addr = regs.y; // We can have only one effective address, so we're choosing the destination
 	}
 	else if (isZprel) {
 		snprintf(line, max_line, mnemonic, real_read6502(pc + 1, debugOn, bank), pc + 3 + (int8_t)real_read6502(pc + 2, debugOn, bank));
@@ -364,7 +365,7 @@ int disasm(uint16_t pc, uint8_t *RAM, char *line, unsigned int max_line, bool de
 				*eff_addr = real_read6502(ptr, debugOn, ind_bank) | (real_read6502(ptr + 1, debugOn, ind_bank) << 8);
 				if (isYrel)
 					*eff_addr += regs.y;
-			} else {
+			} else if (!isImmediate) {
 				*eff_addr = real_read6502(pc + 1, debugOn, bank) | (real_read6502(pc + 2, debugOn, bank) << 8);
 				if (isXrel)
 					*eff_addr += regs.x;

--- a/src/main.c
+++ b/src/main.c
@@ -1402,12 +1402,12 @@ emulator_loop(void *param)
 		if (regs.pc == trace_address && trace_address != 0) {
 			trace_mode = true;
 		}
-		if (trace_mode) {
+		if (trace_mode && !waiting) {
 			char *lst = lst_for_address(regs.pc);
 			if (lst) {
 				char *lf;
 				while ((lf = strchr(lst, '\n'))) {
-					for (int i = 0; i < 116; i++) {
+					for (int i = 0; i < 118; i++) {
 						printf(" ");
 					}
 					if (regs.is65c816) {
@@ -1457,31 +1457,31 @@ emulator_loop(void *param)
 				printf(" ");
 			}
 			if (regs.is65c816) {
-				printf("a=$%04x x=$%04x y=$%04x s=$%04x p=", regs.c, regs.x, regs.y, regs.sp);
+				printf("C=$%04x X=$%04x Y=$%04x S=$%04x P=", regs.c, regs.x, regs.y, regs.sp);
 				for (int i = 7; i >= 0; i--) {
 					printf("%c", (regs.status & (1 << i)) ? "czidxmvn"[i] : '-');
 				}
 
 				putchar(regs.e ? 'e' : '-');
 			} else {
-				printf("a=$%02x x=$%02x y=$%02x s=$%02x p=", regs.a, regs.xl, regs.yl, regs.sp & 0xff);
+				printf("A=$%02x X=$%02x Y=$%02x S=$%02x P=", regs.a, regs.xl, regs.yl, regs.sp & 0xff);
 				for (int i = 7; i >= 0; i--) {
 					printf("%c", (regs.status & (1 << i)) ? "czidb-vn"[i] : '-');
 				}
 			}
 
 			if (eff_addr == 0x9f23) {
-				printf(" v=$%05x   ", video_get_address(0));
+				printf(" VRAM=$%05x ", video_get_address(0));
 			} else if (eff_addr == 0x9f24) {
-				printf(" v=$%05x   ", video_get_address(1));
+				printf(" VRAM=$%05x ", video_get_address(1));
 			} else if (eff_addr >= 0xc000) {
-				printf(" m=$%02x:%04x ", memory_get_rom_bank(), eff_addr);
+				printf(" EA=$%02x:%04x ", memory_get_rom_bank(), eff_addr);
 			} else if (eff_addr >= 0xa000) {
-				printf(" m=$%02x:%04x ", memory_get_ram_bank(), eff_addr);
+				printf(" EA=$%02x:%04x ", memory_get_ram_bank(), eff_addr);
 			} else if (eff_addr >= 0) {
-				printf(" m=$--:%04x ", eff_addr);
+				printf(" EA=$--:%04x ", eff_addr);
 			} else {
-				printf("            ");
+				printf("             ");
 			}
 
 			if (lst) {
@@ -1495,6 +1495,8 @@ emulator_loop(void *param)
 		if (handle_ieee_intercept()) {
 			continue;
 		}
+
+		instruction_counter += waiting ^ 0x1;
 
 		step6502();
 		uint32_t clocks = clockticks6502 - old_clockticks6502;
@@ -1520,8 +1522,6 @@ emulator_loop(void *param)
 		if (!headless) {
 			audio_step(clocks);
 		}
-
-		instruction_counter++;
 
 		if (!headless && new_frame) {
 			if (nvram_dirty && nvram_path) {


### PR DESCRIPTION
* Use upper case register names and lowercase flags (Lichty and Eyes style)
* Change .A to .C in 65C816 mode
* Add effective addr to block moves (destination)
* Remove erroneous effective addr from immediate word ops
* Do not output a trace line, and do not advance the instruction counter while waiting