### PR TITLE
Fix wrong register usage and reset K and DB to 0 upon reset

### DIFF
--- a/src/cpu/instructions.h
+++ b/src/cpu/instructions.h
@@ -465,7 +465,7 @@ static void pha() {
 }
 
 static void phb() {
-    push8(regs.b);
+    push8(regs.db);
 }
 
 static void phd() {
@@ -493,9 +493,9 @@ static void pla() {
 }
 
 static void plb() {
-    regs.b = pull8();
-    zerocalc(regs.b, 0);
-    signcalc(regs.b, 0);
+    regs.db = pull8();
+    zerocalc(regs.db, 0);
+    signcalc(regs.db, 0);
 }
 
 static void pld() {

--- a/src/cpu/support.h
+++ b/src/cpu/support.h
@@ -141,6 +141,8 @@ void reset6502(bool c816) {
     regs.dp = 0;
     regs.sp = 0x1FD;
     regs.e = 1;
+    regs.k = 0;
+    regs.db = 0;
     if (c816) {
         regs.status |= FLAG_INDEX_WIDTH | FLAG_MEMORY_WIDTH;
         regs.is65c816 = true;


### PR DESCRIPTION
- PHB and PLB were using the B register, which is part of the accumulator, and not the DB register, which they are supposed to be using.
- Reset K and DB to 0 upon reset.