### PR TITLE
Fix update kernal status error string

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1366,7 +1366,7 @@ handle_ieee_intercept()
 		clockticks6502 += missed_ticks;
 		if (s >= 0) {
 			if (!set_kernal_status(s)) {
-				printf("Warning: Could not set regs.status!\n");
+				printf("Warning: Could not set STATUS!\n");
 			}
 		}
 


### PR DESCRIPTION
This was mistakenly changed with the 65C816 update.  The status that this refers to is the IEC status (currently at $289 I believe) and has nothing to do with the cpu flags register.