### PR TITLE
IEEE: fix memory allocation blunder

### DIFF
--- a/src/ieee.c
+++ b/src/ieee.c
@@ -568,7 +568,7 @@ resolve_path_utf8(const uint8_t *name, bool must_exist, int wildcard_filetype)
 			}
 
 			// assemble a path with what we have left
-			ret = malloc(u8strlen(tmp)+u8strlen(hostfscwd)+2);
+			ret = malloc(u8strlen(name)+u8strlen(hostfscwd)+2);
 			if (ret == NULL) {
 				free(tmp);
 				set_error(0x70, 0, 0);

--- a/src/smc.c
+++ b/src/smc.c
@@ -42,8 +42,9 @@ smc_read(uint8_t a) {
 				// Reset pwr_long_press so a reset will start normally
 				pwr_long_press = false;
 				return 1;
-			} else	return 0;
-			
+			} else {
+				return 0;
+			}
 		// Offset that returns three bytes from mouse buffer (one movement packet) or a single zero if there is not complete packet in the buffer
 		// mse_count keeps track of which one of the three bytes it's sending
 		case 0x21:


### PR DESCRIPTION
caused malloc buffer overflow for any absolute paths

Closes #260