### PR TITLE
Fix PEI using wraparound behavior

### DIFF
--- a/src/cpu/65c816.opcodes
+++ b/src/cpu/65c816.opcodes
@@ -93,7 +93,7 @@ jsl absl 8 $22
 bra rel 3 $80
 
 pea imm16 5 $f4
-pei ind0 6 $d4
+pei ind0p 6 $d4
 per rel16 6 $62
 phb imp 3 $8b
 phd imp 4 $0b

--- a/src/cpu/buildtables.py
+++ b/src/cpu/buildtables.py
@@ -169,6 +169,7 @@ def convertMnemonic(opInfo):
         "indx": "($%02x,x)",
         "ind": "($%04x)",
         "ind0": "($%02x)",
+        "ind0p": "($%02x)",
         "indl0": "[$%02x]",
         "acc": "a",
         "sr": "$%02x,S",

--- a/src/cpu/modes.h
+++ b/src/cpu/modes.h
@@ -157,6 +157,16 @@ static void indy() { // (indirect),Y
     }
 }
 
+static void ind0p() { // (zp) used by PEI, which doesn't do wraparound calculations
+    uint16_t eahelp;
+    eahelp = (uint16_t)read6502(regs.pc++);
+    ea = (uint16_t)read6502(regs.dp + eahelp) | ((uint16_t)read6502(regs.dp + eahelp + 1) << 8);
+
+    if (regs.dp & 0x00FF) {
+        penaltyd = 1;
+    }
+}
+
 static void zprel() { // zero-page, relative for branch ops (8-bit immediatel value, sign-extended)
 	ea = (uint16_t)read6502(regs.pc);
 	reladdr = (uint16_t)read6502(regs.pc+1);

--- a/src/cpu/modes.h
+++ b/src/cpu/modes.h
@@ -211,12 +211,25 @@ static void aindl() { // [addr]
     eal = read6502(regs.pc++);
 }
 
+static void _zp_long_with_offset(uint16_t offset) {
+    uint16_t eahelp;
+    eahelp = (uint16_t)read6502(regs.pc++);
+
+    uint32_t ea32 = (uint16_t)read6502(regs.dp + eahelp) | ((uint16_t)read6502(regs.dp + eahelp + 1) << 8) | ((uint16_t)read6502(regs.dp + eahelp + 2) << 16);
+    ea32 += offset;
+
+    ea = (uint16_t) ea32;
+    eal = (uint8_t) (ea32 >> 16);
+
+    if (regs.dp & 0x00FF) {
+        penaltyd = 1;
+    }
+}
+
 static void indl0() { // [dp]
-    ind0();
-    eal = read6502(regs.pc++);
+    _zp_long_with_offset(0);
 }
 
 static void indly() { // [dp],Y
-    indy();
-    eal = read6502(regs.pc++);
+    _zp_long_with_offset(regs.y);
 }

--- a/src/cpu/tables.h
+++ b/src/cpu/tables.h
@@ -35,7 +35,7 @@ static void (*addrtable_c816[256])() = {
 /* A */    immx, indx, immx,   sr,   zp,   zp,   zp,indl0,  imp, immm,  imp,  imp, abso, abso, abso, absl, /* A */
 /* B */     rel, indy, ind0,sridy,  zpx,  zpx,  zpy,indly,  imp, absy,  imp,  imp, absx, absx, absy,abslx, /* B */
 /* C */    immx, indx, imm8,   sr,   zp,   zp,   zp,indl0,  imp, immm,  imp,  imp, abso, abso, abso, absl, /* C */
-/* D */     rel, indy, ind0,sridy, ind0,  zpx,  zpx,indly,  imp, absy,  imp,  imp,aindl, absx, absx,abslx, /* D */
+/* D */     rel, indy, ind0,sridy,ind0p,  zpx,  zpx,indly,  imp, absy,  imp,  imp,aindl, absx, absx,abslx, /* D */
 /* E */    immx, indx, imm8,   sr,   zp,   zp,   zp,indl0,  imp, immm,  imp,  imp, abso, abso, abso, absl, /* E */
 /* F */     rel, indy, ind0,sridy,imm16,  zpx,  zpx,indly,  imp, absy,  imp,  imp, ainx, absx, absx,abslx  /* F */
 };


### PR DESCRIPTION
PEI always behaves like in native mode, even in emulation mode, and does not implement any of the emulation mode wraparound behavior.