### PR TITLE
Clear high bytes of X and Y registers when entering 8 bit mode using PLP or RTI

### DIFF
--- a/src/cpu/instructions.h
+++ b/src/cpu/instructions.h
@@ -552,6 +552,10 @@ static void rti() {
     if (regs.e) {
         regs.status |= FLAG_INDEX_WIDTH | FLAG_MEMORY_WIDTH;
     } else {
+        if (regs.status & FLAG_INDEX_WIDTH) {
+            regs.xh = 0;
+            regs.yh = 0;
+        }
         regs.k = pull8();
     }
 }

--- a/src/cpu/instructions.h
+++ b/src/cpu/instructions.h
@@ -518,7 +518,7 @@ static void rep() {
 
     if (regs.e) {
         regs.status |= FLAG_INDEX_WIDTH | FLAG_MEMORY_WIDTH;
-    } 
+    }
 }
 
 static void rol() {

--- a/src/cpu/instructions.h
+++ b/src/cpu/instructions.h
@@ -506,6 +506,9 @@ static void plp() {
     regs.status = pull8();
     if (regs.e) {
         regs.status |= FLAG_INDEX_WIDTH | FLAG_MEMORY_WIDTH;
+    } else if (regs.status & FLAG_INDEX_WIDTH) {
+        regs.xh = 0;
+        regs.yh = 0;
     }
 }
 
@@ -515,7 +518,7 @@ static void rep() {
 
     if (regs.e) {
         regs.status |= FLAG_INDEX_WIDTH | FLAG_MEMORY_WIDTH;
-    }
+    } 
 }
 
 static void rol() {


### PR DESCRIPTION
Fixes a bug with the 65816 emulation where PLP and RTI wouldn't clear the high bytes of the X and Y index registers.

Below is a screenshot from an unpatched version of the emulator, which demonstrates the problematic behavior
![image](https://github.com/X16Community/x16-emulator/assets/72891927/0606a218-3055-44e2-9818-a08430200b70)
