### PR TITLE
Allow addition of RAM option to the Web emulator

### DIFF
--- a/webassembly/main.js
+++ b/webassembly/main.js
@@ -70,8 +70,13 @@ if (layouts.includes(lang)) {
 
 var url = new URL(window.location.href);
 var manifest_link = url.searchParams.get("manifest");
+var ram_val = url.searchParams.get("ram");
 
 var emuArguments = ['-keymap', lang, '-rtc'];
+
+if (ram_val) {
+    emuArguments.push('-ram', ram_val);
+}
 
 if (manifest_link) {
     openFs();


### PR DESCRIPTION
This will allow the web emulator to be called with ram=xxxx option where xxxx is the amount of memory you want the emulator to have.

On the forum site, the link could look something like this:
https://cx16forum.com/webemu/x16emu.html?manifest=/forum/download/file.php?id=1218&ram=2048