### PR TITLE
Debugger: correct display of overflow values, stack read is a debug op

### DIFF
--- a/src/debugger.c
+++ b/src/debugger.c
@@ -903,7 +903,7 @@ static void DEBUGRenderStack(int bytesCount) {
 	int y= 0;
 	while (y < bytesCount) {
 		DEBUGNumber(DBG_STCK,y, sp,4, col_label);
-		int byte = real_read6502(sp, false, 0);
+		int byte = real_read6502(sp, true, 0);
 		DEBUGNumber(DBG_STCK+5,y,byte,2, col_data);
 		DEBUGWrite(dbgRenderer, DBG_STCK+9,y,byte, col_data);
 		y++;

--- a/src/disasm.c
+++ b/src/disasm.c
@@ -403,5 +403,9 @@ int disasm(uint16_t pc, uint8_t *RAM, char *line, unsigned int max_line, bool de
 		free((char *) mnemonic);
 	}
 
+	if (eff_addr >= 0x10000) {
+		*eff_addr &= 0xffff;
+	}
+
 	return length;
 }

--- a/src/disasm.c
+++ b/src/disasm.c
@@ -403,7 +403,7 @@ int disasm(uint16_t pc, uint8_t *RAM, char *line, unsigned int max_line, bool de
 		free((char *) mnemonic);
 	}
 
-	if (eff_addr >= 0x10000) {
+	if (*eff_addr >= 0x10000) {
 		*eff_addr &= 0xffff;
 	}
 

--- a/src/video.c
+++ b/src/video.c
@@ -1545,7 +1545,7 @@ uint32_t
 video_get_address(uint8_t sel)
 {
 	uint32_t address = io_addr[sel];
-	return address;
+	return address & 0x1ffff;
 }
 
 uint32_t


### PR DESCRIPTION
Fixing a few display issues in the debugger, including changing the reading of the stack to being a debug read and not an execution read.