### PR TITLE
base SPI clock on the VERA clock

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1549,7 +1549,7 @@ emulator_loop(void *param)
 		old_clockticks6502 = clockticks6502;
 		bool new_frame = false;
 		via1_step(clocks);
-		vera_spi_step(clocks);
+		vera_spi_step(MHZ, clocks);
 		if (has_serial) {
 			serial_step(clocks);
 		}

--- a/src/vera_spi.c
+++ b/src/vera_spi.c
@@ -6,11 +6,13 @@
 #include <stdbool.h>
 #include "sdcard.h"
 
+#define SPI_CLOCK_RATE_MHZ 12.5f
+
 bool ss;
 bool busy;
 bool autotx;
 uint8_t sending_byte, received_byte;
-int outcounter;
+float outcounter;
 
 void
 vera_spi_init()
@@ -22,10 +24,10 @@ vera_spi_init()
 }
 
 void
-vera_spi_step(int clocks)
+vera_spi_step(int mhz, int clocks)
 {
 	if (busy) {
-		outcounter += clocks;
+		outcounter += (float)clocks * SPI_CLOCK_RATE_MHZ / (float)mhz;
 		if (outcounter >= 8) {
 			busy = false;
 			if (sdcard_attached) {

--- a/src/vera_spi.h
+++ b/src/vera_spi.h
@@ -5,6 +5,6 @@
 #include <inttypes.h>
 
 void vera_spi_init();
-void vera_spi_step(int clocks);
+void vera_spi_step(int mhz, int clocks);
 uint8_t vera_spi_read(uint8_t address);
 void vera_spi_write(uint8_t address, uint8_t value);


### PR DESCRIPTION
Erroneously clocking SPI used to be based on the CPU clock.