### PR TITLE
Various minor header fixups

### DIFF
--- a/src/files.c
+++ b/src/files.c
@@ -9,6 +9,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <unistd.h>
+#include <stdio.h>
 #include <SDL.h>
 #include <zlib.h>
 #include <inttypes.h>

--- a/src/memory.c
+++ b/src/memory.c
@@ -7,6 +7,7 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <time.h>
+#include <inttypes.h>
 #include "glue.h"
 #include "via.h"
 #include "memory.h"

--- a/src/sdcard.c
+++ b/src/sdcard.c
@@ -10,6 +10,7 @@
 #include <limits.h>
 #include <stdio.h>
 #include <stdbool.h>
+#include <string.h>
 #include "sdcard.h"
 #include "files.h"
 

--- a/src/testbench.c
+++ b/src/testbench.c
@@ -4,6 +4,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include "memory.h"
 #include "cpu/fake6502.h"
 #include "glue.h"

--- a/src/utf8_encode.h
+++ b/src/utf8_encode.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <stdint.h>
 
 /**

--- a/src/video_win32.c
+++ b/src/video_win32.c
@@ -3,7 +3,7 @@
 #include <SDL.h>
 #include <SDL_syswm.h>
 
-#include <Windows.h>
+#include <windows.h>
 #include <dwmapi.h>
 
 void video_win32_set_rounded_corners(SDL_Window *window)

--- a/src/wav_recorder.c
+++ b/src/wav_recorder.c
@@ -9,6 +9,7 @@
 #include "glue.h"
 #include <string.h>
 #include <stdlib.h>
+#include <stdio.h>
 
 #pragma pack(push, 1)
 typedef struct {


### PR DESCRIPTION
* src/files.c: stdio.h for printf
* src/memory.c: inttypes.h for PRIu64
* src/sdcard.c: string.h for strncpy
* src/testbench.c: string.h for strncpy
* src/utf8_encode.h: include guard
* src/video_win32.c: de facto standard case for windows.h
* src/wav_recorder.c: stdio.h for printf

I ran into all but one of the above compiling with Mingw-w64. The case for windows.h is important for cross-compilation, and on case-sensitive file systems it's always all lowercase. The missing include guard in utf8_encode.h isn't normally a problem, but it affects my custom unity build and its omission is likely an accident.