### PR TITLE
Fix some invalid left shifts (undefined behavior)

### DIFF
--- a/src/audio.c
+++ b/src/audio.c
@@ -292,8 +292,8 @@ audio_render()
 		// Don't resample VERA outputs if the host sample rate is as desired
 		if (host_sample_rate == AUDIO_SAMPLERATE) {
 			pos = (vera_samp_pos_rd >> SAMP_POS_FRAC_BITS) * 2;
-			vera_out_l = ((int32_t)psg_buf[pos] + pcm_buf[pos]) << 14;
-			vera_out_r = ((int32_t)psg_buf[pos + 1] + pcm_buf[pos + 1]) << 14;
+			vera_out_l = ((uint32_t)psg_buf[pos] + pcm_buf[pos]) << 14;
+			vera_out_r = ((uint32_t)psg_buf[pos + 1] + pcm_buf[pos + 1]) << 14;
 		} else {
 			filter_idx = (vera_samp_pos_rd >> (SAMP_POS_FRAC_BITS - 8)) & 0xff;
 			pos = (vera_samp_pos_rd >> SAMP_POS_FRAC_BITS) * 2;

--- a/src/video.c
+++ b/src/video.c
@@ -838,8 +838,8 @@ render_layer_line_tile(uint8_t layer, uint16_t y)
 	const int     eff_y               = calc_layer_eff_y(props0, y);
 	const uint8_t yy                  = eff_y & props->tileh_max;
 	const uint8_t yy_flip             = yy ^ props->tileh_max;
-	const uint32_t y_add              = (yy << (props->tilew_log2 + props->color_depth - 3));
-	const uint32_t y_add_flip         = (yy_flip << (props->tilew_log2 + props->color_depth - 3));
+	const uint32_t y_add              = (yy << ((props->tilew_log2 + props->color_depth - 3) & 31));
+	const uint32_t y_add_flip         = (yy_flip << ((props->tilew_log2 + props->color_depth - 3) & 31));
 
 	const uint32_t map_addr_begin = calc_layer_map_addr_base2(props, props->min_eff_x, eff_y);
 	const uint32_t map_addr_end   = calc_layer_map_addr_base2(props, props->max_eff_x, eff_y);


### PR DESCRIPTION
In src/audio.c, samples may be negative and left shifting a negative value is undefined behavior (signed overflow). Unsigned left-shift is well-defined and produces the desired results, so use an unsigned operand.

In src/video.c the left-shift right-side operands are negative in some cases, the results are which are undefined. In practice, on x86 hosts it typically behaves as though masked per this commit. The mask preserves the most likely current behavior using well-defined semantics.

There is one more frequent left-shift signed overflow in ymfm_opm.cpp (opm_registers::opm_registers, shifting pm). Since this is a vendored dependency I haven not included a fix in this commit, but fixing it is similarly simple.

All caught with Undefined Behavior Sanitizer (-fsanitize=undefined).