### PR TITLE
Add emulated Serial MIDI synthesizer support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,7 +65,7 @@ jobs:
         run: |
           git reset --hard
           git diff
-          TRACE=1 CROSS_COMPILE_WINDOWS=1 SDL2CONFIG=sdl2-config make V=1 -j2
+          TRACE=1 FLUIDSYNTH=1 CROSS_COMPILE_WINDOWS=1 SDL2CONFIG=sdl2-config make V=1 -j2
           mkdir emu_binaries
           cp $(which SDL2.dll) emu_binaries/.
           cp $(which zlib1.dll) emu_binaries/.
@@ -151,7 +151,7 @@ jobs:
         run: |
           git reset --hard
           git diff
-          TRACE=1 WIN_SDL2=/mingw32 TARGET_CPU=x86 CROSS_COMPILE_WINDOWS=1 make V=1 -j2
+          TRACE=1 FLUIDSYNTH=1 WIN_SDL2=/mingw32 TARGET_CPU=x86 CROSS_COMPILE_WINDOWS=1 make V=1 -j2
           mkdir emu_binaries
           cp $(which SDL2.dll) emu_binaries/.
           cp $(which zlib1.dll) emu_binaries/.
@@ -227,7 +227,7 @@ jobs:
           cp latest_rom/*.h src/.
       - name: Build Emulator
         run: |
-          TRACE=1 make V=1 -j3
+          TRACE=1 FLUIDSYNTH=1 make V=1 -j3
           mkdir emu_binaries
           cp sdcard.img.zip emu_binaries/.
           cp x16emu emu_binaries/.
@@ -286,7 +286,7 @@ jobs:
           commands: |
             apt-get update
             apt-get install -y build-essential make libsdl2-dev file git libfluidsynth-dev
-            TRACE=1 make V=1 -j3
+            TRACE=1 FLUIDSYNTH=1 make V=1 -j3
             mkdir emu_binaries
             cp sdcard.img.zip emu_binaries/.
             cp x16emu emu_binaries/.
@@ -346,7 +346,7 @@ jobs:
           commands: |
             apt-get update
             apt-get install -y build-essential make libsdl2-dev file git libfluidsynth-dev
-            TRACE=1 make V=1 -j3
+            TRACE=1 FLUIDSYNTH=1 make V=1 -j3
             mkdir emu_binaries
             cp sdcard.img.zip emu_binaries/.
             cp x16emu emu_binaries/.
@@ -398,7 +398,7 @@ jobs:
           cp latest_rom/*.h src/.
       - name: Build Emulator
         run: |
-          TRACE=1 MAC_STATIC=1 HOMEBREW_LIB=/usr/local/lib make V=1 -j3
+          TRACE=1 MAC_STATIC=1 LIBSDL_FILE=/usr/local/Cellar/sdl2/*/lib/libSDL2.a HOMEBREW_LIB=/usr/local/lib make V=1 -j3
           mkdir emu_binaries
           cp sdcard.img.zip emu_binaries/.
           cp x16emu emu_binaries/.
@@ -448,7 +448,7 @@ jobs:
           cp latest_rom/*.h src/.
       - name: Build Emulator
         run: |
-          TRACE=1 MAC_STATIC=1 ADDL_INCLUDE=/opt/homebrew/include HOMEBREW_LIB=/opt/homebrew/lib make V=1 -j3
+          TRACE=1 MAC_STATIC=1 LIBSDL_FILE=/opt/homebrew/Cellar/sdl2/*/lib/libSDL2.a ADDL_INCLUDE=/opt/homebrew/include HOMEBREW_LIB=/opt/homebrew/lib FLUIDSYNTH=1 make V=1 -j3
           mkdir emu_binaries
           cp sdcard.img.zip emu_binaries/.
           cp x16emu emu_binaries/.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,6 +71,7 @@ jobs:
           cp $(which zlib1.dll) emu_binaries/.
           cp $(which libwinpthread-1.dll) emu_binaries/.
           cp $(which libfluidsynth-3.dll) emu_binaries/.
+          cp $(which libgcc_s_seh-1.dll) emu_binaries/.
           cp sdcard.img.zip emu_binaries/.
           cp x16emu.exe emu_binaries/.
           cp makecart.exe emu_binaries/.
@@ -138,6 +139,7 @@ jobs:
           cp $(which zlib1.dll) emu_binaries/.
           cp $(which libwinpthread-1.dll) emu_binaries/.
           cp $(which libfluidsynth-3.dll) emu_binaries/.
+          cp $(which libgcc_s_seh-1.dll) emu_binaries/.
           cp sdcard.img.zip emu_binaries/.
           cp x16emu.exe emu_binaries/.
           cp makecart.exe emu_binaries/.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           msystem: MINGW64
           update: true
-          install: make git mingw-w64-x86_64-toolchain mingw-w64-x86_64-libelf mingw-w64-x86_64-SDL2
+          install: make git mingw-w64-x86_64-toolchain mingw-w64-x86_64-libelf mingw-w64-x86_64-SDL2 mingw-w64-x86_64-fluidsynth
       - uses: actions/setup-python@v5
         with:
           python-version: '3.9'
@@ -103,7 +103,7 @@ jobs:
         with:
           msystem: MINGW64
           update: true
-          install: make git mingw-w64-i686-toolchain mingw-w64-i686-libelf mingw-w64-i686-SDL2
+          install: make git mingw-w64-i686-toolchain mingw-w64-i686-libelf mingw-w64-i686-SDL2 mingw-w64-i686-fluidsynth
           path-type: inherit
       - uses: actions/setup-python@v5
         with:
@@ -165,7 +165,7 @@ jobs:
         with:
           python-version: '3.9'
       - name: Install Dependencies
-        run: sudo apt-get update && sudo apt-get install -y build-essential make libsdl2-dev
+        run: sudo apt-get update && sudo apt-get install -y build-essential make libsdl2-dev libfluidsynth-dev
       - name: Fetch latest ROM
         if: startsWith(github.ref, 'refs/tags/r') != true
         run: |
@@ -241,7 +241,7 @@ jobs:
           copy_artifact_path: emu_binaries
           commands: |
             apt-get update
-            apt-get install -y build-essential make libsdl2-dev file git
+            apt-get install -y build-essential make libsdl2-dev file git libfluidsynth-dev
             TRACE=1 make V=1 -j3
             mkdir emu_binaries
             cp sdcard.img.zip emu_binaries/.
@@ -301,7 +301,7 @@ jobs:
           copy_artifact_path: emu_binaries
           commands: |
             apt-get update
-            apt-get install -y build-essential make libsdl2-dev file git
+            apt-get install -y build-essential make libsdl2-dev file git libfluidsynth-dev
             TRACE=1 make V=1 -j3
             mkdir emu_binaries
             cp sdcard.img.zip emu_binaries/.
@@ -333,7 +333,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install Dependencies
         run: | 
-          brew install make sdl2 
+          brew install make sdl2 fluid-synth
       - uses: actions/setup-python@v5
         with:
           python-version: '3.9'
@@ -383,7 +383,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install Dependencies
         run: | 
-          brew install make sdl2 
+          brew install make sdl2 fluid-synth
       - uses: actions/setup-python@v5
         with:
           python-version: '3.10'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -223,6 +223,8 @@ jobs:
           cp latest_rom/*.h src/.
       - name: Build Emulator
         run: |
+          dpkg-query -L libfluidsynth-dev
+          dpkg-query -L libfluidsynth2
           TRACE=1 make V=1 -j3
           mkdir emu_binaries
           cp sdcard.img.zip emu_binaries/.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -404,6 +404,7 @@ jobs:
           cp latest_rom/*.h src/.
       - name: Build Emulator
         run: |
+          find /opt/homebrew/include
           TRACE=1 MAC_STATIC=1 FLUIDSYNTH_INCLUDE=/opt/homebrew/include/fluid-synth LIBSDL_FILE=/opt/homebrew/Cellar/sdl2/*/lib/libSDL2.a make V=1 -j3
           mkdir emu_binaries
           cp sdcard.img.zip emu_binaries/.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -354,7 +354,7 @@ jobs:
           cp latest_rom/*.h src/.
       - name: Build Emulator
         run: |
-          TRACE=1 MAC_STATIC=1 LIBSDL_FILE=/usr/local/Cellar/sdl2/*/lib/libSDL2.a make V=1 -j3
+          TRACE=1 MAC_STATIC=1 $(pkg-config --cflags fluid-synth) LIBSDL_FILE=/usr/local/Cellar/sdl2/*/lib/libSDL2.a make V=1 -j3
           mkdir emu_binaries
           cp sdcard.img.zip emu_binaries/.
           cp x16emu emu_binaries/.
@@ -405,7 +405,7 @@ jobs:
       - name: Build Emulator
         run: |
           find /opt/homebrew/include
-          TRACE=1 MAC_STATIC=1 FLUIDSYNTH_INCLUDE=/opt/homebrew/include/fluid-synth LIBSDL_FILE=/opt/homebrew/Cellar/sdl2/*/lib/libSDL2.a make V=1 -j3
+          TRACE=1 MAC_STATIC=1 $(pkg-config --cflags fluid-synth) LIBSDL_FILE=/opt/homebrew/Cellar/sdl2/*/lib/libSDL2.a make V=1 -j3
           mkdir emu_binaries
           cp sdcard.img.zip emu_binaries/.
           cp x16emu emu_binaries/.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,7 +78,7 @@ jobs:
           cp $(which libintl-8.dll) emu_binaries/.
           cp $(which libstdc++-6.dll) emu_binaries/.
           cp $(which libgomp-1.dll) emu_binaries/.
-          cp $(which libreadline-8.dll) emu_binaries/.
+          cp $(which libreadline8.dll) emu_binaries/.
           cp $(which libsndfile-1.dll) emu_binaries/.
           cp sdcard.img.zip emu_binaries/.
           cp x16emu.exe emu_binaries/.
@@ -154,7 +154,7 @@ jobs:
           cp $(which libintl-8.dll) emu_binaries/.
           cp $(which libstdc++-6.dll) emu_binaries/.
           cp $(which libgomp-1.dll) emu_binaries/.
-          cp $(which libreadline-8.dll) emu_binaries/.
+          cp $(which libreadline8.dll) emu_binaries/.
           cp $(which libsndfile-1.dll) emu_binaries/.
           cp sdcard.img.zip emu_binaries/.
           cp x16emu.exe emu_binaries/.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,6 +74,7 @@ jobs:
           cp $(which libgcc_s_seh-1.dll) emu_binaries/.
           cp $(which libglib-2.0-0.dll) emu_binaries/.
           cp $(which libgmodule-2.0-0.dll) emu_binaries/.
+          cp $(which libportaudio.dll) emu_binaries/.
           cp sdcard.img.zip emu_binaries/.
           cp x16emu.exe emu_binaries/.
           cp makecart.exe emu_binaries/.
@@ -144,6 +145,7 @@ jobs:
           cp $(which libgcc_s_seh-1.dll) emu_binaries/.
           cp $(which libglib-2.0-0.dll) emu_binaries/.
           cp $(which libgmodule-2.0-0.dll) emu_binaries/.
+          cp $(which libportaudio.dll) emu_binaries/.
           cp sdcard.img.zip emu_binaries/.
           cp x16emu.exe emu_binaries/.
           cp makecart.exe emu_binaries/.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,6 +72,8 @@ jobs:
           cp $(which libwinpthread-1.dll) emu_binaries/.
           cp $(which libfluidsynth-3.dll) emu_binaries/.
           cp $(which libgcc_s_seh-1.dll) emu_binaries/.
+          cp $(which libglib-2.0-0.dll) emu_binaries/.
+          cp $(which libgmodule-2.0-0.dll) emu_binaries/.
           cp sdcard.img.zip emu_binaries/.
           cp x16emu.exe emu_binaries/.
           cp makecart.exe emu_binaries/.
@@ -140,6 +142,8 @@ jobs:
           cp $(which libwinpthread-1.dll) emu_binaries/.
           cp $(which libfluidsynth-3.dll) emu_binaries/.
           cp $(which libgcc_s_seh-1.dll) emu_binaries/.
+          cp $(which libglib-2.0-0.dll) emu_binaries/.
+          cp $(which libgmodule-2.0-0.dll) emu_binaries/.
           cp sdcard.img.zip emu_binaries/.
           cp x16emu.exe emu_binaries/.
           cp makecart.exe emu_binaries/.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -214,7 +214,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Pull down and build FluidSynth
         run: |
-          sudo apt-get build-dep fluidsynth --no-install-recommends
+          sudo apt-get build-dep fluidsynth2 --no-install-recommends
           git clone https://github.com/FluidSynth/fluidsynth.git
           cd fluidsynth
           mkdir build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -404,7 +404,7 @@ jobs:
           cp latest_rom/*.h src/.
       - name: Build Emulator
         run: |
-          TRACE=1 MAC_STATIC=1 LIBSDL_FILE=/opt/homebrew/Cellar/sdl2/*/lib/libSDL2.a make V=1 -j3
+          TRACE=1 MAC_STATIC=1 FLUIDSYNTH_INCLUDE=/opt/homebrew/include/fluid-synth LIBSDL_FILE=/opt/homebrew/Cellar/sdl2/*/lib/libSDL2.a make V=1 -j3
           mkdir emu_binaries
           cp sdcard.img.zip emu_binaries/.
           cp x16emu emu_binaries/.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -404,8 +404,7 @@ jobs:
           cp latest_rom/*.h src/.
       - name: Build Emulator
         run: |
-          brew ls --verbose fluid-synth
-          TRACE=1 MAC_STATIC=1 $(pkg-config --cflags fluid-synth) LIBSDL_FILE=/opt/homebrew/Cellar/sdl2/*/lib/libSDL2.a make V=1 -j3
+          TRACE=1 MAC_STATIC=1 -I$(dirname $(find /opt/homebrew/Cellar/fluid-synth/ -name fluidsynth.h)) LIBSDL_FILE=/opt/homebrew/Cellar/sdl2/*/lib/libSDL2.a make V=1 -j3
           mkdir emu_binaries
           cp sdcard.img.zip emu_binaries/.
           cp x16emu emu_binaries/.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,6 +70,7 @@ jobs:
           cp $(which SDL2.dll) emu_binaries/.
           cp $(which zlib1.dll) emu_binaries/.
           cp $(which libwinpthread-1.dll) emu_binaries/.
+          cp $(which libfluidsynth-3.dll) emu_binaries/.
           cp sdcard.img.zip emu_binaries/.
           cp x16emu.exe emu_binaries/.
           cp makecart.exe emu_binaries/.
@@ -136,6 +137,7 @@ jobs:
           cp $(which SDL2.dll) emu_binaries/.
           cp $(which zlib1.dll) emu_binaries/.
           cp $(which libwinpthread-1.dll) emu_binaries/.
+          cp $(which libfluidsynth-3.dll) emu_binaries/.
           cp sdcard.img.zip emu_binaries/.
           cp x16emu.exe emu_binaries/.
           cp makecart.exe emu_binaries/.
@@ -404,7 +406,7 @@ jobs:
           cp latest_rom/*.h src/.
       - name: Build Emulator
         run: |
-          TRACE=1 MAC_STATIC=1 -I$(dirname $(find /opt/homebrew/Cellar/fluid-synth/ -name fluidsynth.h)) LIBSDL_FILE=/opt/homebrew/Cellar/sdl2/*/lib/libSDL2.a make V=1 -j3
+          TRACE=1 MAC_STATIC=1 ADDL_INCLUDE=$(dirname $(find /opt/homebrew/Cellar/fluid-synth -name fluidsynth.h)) LIBSDL_FILE=/opt/homebrew/Cellar/sdl2/*/lib/libSDL2.a make V=1 -j3
           mkdir emu_binaries
           cp sdcard.img.zip emu_binaries/.
           cp x16emu emu_binaries/.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -205,13 +205,23 @@ jobs:
         with:
           python-version: '3.9'
       - name: Install Dependencies
-        run: sudo apt-get update && sudo apt-get install -y build-essential make libsdl2-dev libfluidsynth-dev
+        run: sudo apt-get update && sudo apt-get install -y build-essential make libsdl2-dev cmake
       - name: Fetch latest ROM
         if: startsWith(github.ref, 'refs/tags/r') != true
         run: |
           gh run download -R X16Community/x16-rom -n "ROM Image" --dir latest_rom
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Pull down and build FluidSynth
+        run: |
+          sudo apt-get build-dep fluidsynth --no-install-recommends
+          git clone https://github.com/FluidSynth/fluidsynth.git
+          cd fluidsynth
+          mkdir build
+          cd build
+          cmake .. -DCMAKE_INSTALL_PREFIX=/usr -DBUILD_SHARED_LIBS=0
+          make libfluidsynth
+          sudo make install
       - name: Fetch latest release ROM
         if: startsWith(github.ref, 'refs/tags/r')
         run: |
@@ -223,8 +233,6 @@ jobs:
           cp latest_rom/*.h src/.
       - name: Build Emulator
         run: |
-          dpkg-query -L libfluidsynth-dev
-          dpkg-query -L libfluidsynth2
           TRACE=1 make V=1 -j3
           mkdir emu_binaries
           cp sdcard.img.zip emu_binaries/.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -205,7 +205,11 @@ jobs:
         with:
           python-version: '3.9'
       - name: Install Dependencies
-        run: sudo apt-get update && sudo apt-get install -y build-essential make libsdl2-dev cmake
+        run: |
+          sudo cp /etc/apt/sources.list /etc/apt/sources.list~
+          sudo sed -Ei 's/^# deb-src /deb-src /' /etc/apt/sources.list
+          sudo apt-get update
+          sudo apt-get install -y build-essential make libsdl2-dev cmake
       - name: Fetch latest ROM
         if: startsWith(github.ref, 'refs/tags/r') != true
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -394,7 +394,7 @@ jobs:
           cp latest_rom/*.h src/.
       - name: Build Emulator
         run: |
-          TRACE=1 MAC_STATIC=1 LIBSDL_FILE=/usr/local/Cellar/sdl2/*/lib/libSDL2.a make V=1 -j3
+          TRACE=1 MAC_STATIC=1 HOMEBREW_LIB=/usr/local/lib make V=1 -j3
           mkdir emu_binaries
           cp sdcard.img.zip emu_binaries/.
           cp x16emu emu_binaries/.
@@ -444,7 +444,7 @@ jobs:
           cp latest_rom/*.h src/.
       - name: Build Emulator
         run: |
-          TRACE=1 MAC_STATIC=1 ADDL_INCLUDE=$(dirname $(find /opt/homebrew/Cellar/fluid-synth -name fluidsynth.h)) LIBSDL_FILE=/opt/homebrew/Cellar/sdl2/*/lib/libSDL2.a make V=1 -j3
+          TRACE=1 MAC_STATIC=1 ADDL_INCLUDE=/opt/homebrew/include HOMEBREW_LIB=/opt/homebew/lib make V=1 -j3
           mkdir emu_binaries
           cp sdcard.img.zip emu_binaries/.
           cp x16emu emu_binaries/.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -354,7 +354,7 @@ jobs:
           cp latest_rom/*.h src/.
       - name: Build Emulator
         run: |
-          TRACE=1 MAC_STATIC=1 $(pkg-config --cflags fluid-synth) LIBSDL_FILE=/usr/local/Cellar/sdl2/*/lib/libSDL2.a make V=1 -j3
+          TRACE=1 MAC_STATIC=1 LIBSDL_FILE=/usr/local/Cellar/sdl2/*/lib/libSDL2.a make V=1 -j3
           mkdir emu_binaries
           cp sdcard.img.zip emu_binaries/.
           cp x16emu emu_binaries/.
@@ -404,7 +404,7 @@ jobs:
           cp latest_rom/*.h src/.
       - name: Build Emulator
         run: |
-          find /opt/homebrew/include
+          brew ls --verbose fluid-synth
           TRACE=1 MAC_STATIC=1 $(pkg-config --cflags fluid-synth) LIBSDL_FILE=/opt/homebrew/Cellar/sdl2/*/lib/libSDL2.a make V=1 -j3
           mkdir emu_binaries
           cp sdcard.img.zip emu_binaries/.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,6 +80,16 @@ jobs:
           cp $(which libgomp-1.dll) emu_binaries/.
           cp $(which libreadline8.dll) emu_binaries/.
           cp $(which libsndfile-1.dll) emu_binaries/.
+          cp $(which libpcre2-8-0.dll) emu_binaries/.
+          cp $(which libiconv-2.dll) emu_binaries/.
+          cp $(which libtermcap-0.dll) emu_binaries/.
+          cp $(which libFLAC.dll) emu_binaries/.
+          cp $(which libmp3lame-0.dll) emu_binaries/.
+          cp $(which libmpg123-0.dll) emu_binaries/.
+          cp $(which libogg-0.dll) emu_binaries/.
+          cp $(which libopus-0.dll) emu_binaries/.
+          cp $(which libvorbis-0.dll) emu_binaries/.
+          cp $(which libvorbisenc-2.dll) emu_binaries/.
           cp sdcard.img.zip emu_binaries/.
           cp x16emu.exe emu_binaries/.
           cp makecart.exe emu_binaries/.
@@ -156,6 +166,16 @@ jobs:
           cp $(which libgomp-1.dll) emu_binaries/.
           cp $(which libreadline8.dll) emu_binaries/.
           cp $(which libsndfile-1.dll) emu_binaries/.
+          cp $(which libpcre2-8-0.dll) emu_binaries/.
+          cp $(which libiconv-2.dll) emu_binaries/.
+          cp $(which libtermcap-0.dll) emu_binaries/.
+          cp $(which libFLAC.dll) emu_binaries/.
+          cp $(which libmp3lame-0.dll) emu_binaries/.
+          cp $(which libmpg123-0.dll) emu_binaries/.
+          cp $(which libogg-0.dll) emu_binaries/.
+          cp $(which libopus-0.dll) emu_binaries/.
+          cp $(which libvorbis-0.dll) emu_binaries/.
+          cp $(which libvorbisenc-2.dll) emu_binaries/.
           cp sdcard.img.zip emu_binaries/.
           cp x16emu.exe emu_binaries/.
           cp makecart.exe emu_binaries/.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,6 +75,11 @@ jobs:
           cp $(which libglib-2.0-0.dll) emu_binaries/.
           cp $(which libgmodule-2.0-0.dll) emu_binaries/.
           cp $(which libportaudio.dll) emu_binaries/.
+          cp $(which libintl-8.dll) emu_binaries/.
+          cp $(which libstdc++-6.dll) emu_binaries/.
+          cp $(which libgomp-1.dll) emu_binaries/.
+          cp $(which libreadline-8.dll) emu_binaries/.
+          cp $(which libsndfile-1.dll) emu_binaries/.
           cp sdcard.img.zip emu_binaries/.
           cp x16emu.exe emu_binaries/.
           cp makecart.exe emu_binaries/.
@@ -146,6 +151,11 @@ jobs:
           cp $(which libglib-2.0-0.dll) emu_binaries/.
           cp $(which libgmodule-2.0-0.dll) emu_binaries/.
           cp $(which libportaudio.dll) emu_binaries/.
+          cp $(which libintl-8.dll) emu_binaries/.
+          cp $(which libstdc++-6.dll) emu_binaries/.
+          cp $(which libgomp-1.dll) emu_binaries/.
+          cp $(which libreadline-8.dll) emu_binaries/.
+          cp $(which libsndfile-1.dll) emu_binaries/.
           cp sdcard.img.zip emu_binaries/.
           cp x16emu.exe emu_binaries/.
           cp makecart.exe emu_binaries/.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -209,23 +209,13 @@ jobs:
           sudo cp /etc/apt/sources.list /etc/apt/sources.list~
           sudo sed -Ei 's/^# deb-src /deb-src /' /etc/apt/sources.list
           sudo apt-get update
-          sudo apt-get install -y build-essential make libsdl2-dev cmake
+          sudo apt-get install -y build-essential make libsdl2-dev libfluidsynth-dev
       - name: Fetch latest ROM
         if: startsWith(github.ref, 'refs/tags/r') != true
         run: |
           gh run download -R X16Community/x16-rom -n "ROM Image" --dir latest_rom
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Pull down and build FluidSynth
-        run: |
-          sudo apt-get build-dep fluidsynth --no-install-recommends
-          git clone https://github.com/FluidSynth/fluidsynth.git
-          cd fluidsynth
-          mkdir build
-          cd build
-          cmake .. -DCMAKE_INSTALL_PREFIX=/usr -DBUILD_SHARED_LIBS=0
-          make libfluidsynth
-          sudo make install
       - name: Fetch latest release ROM
         if: startsWith(github.ref, 'refs/tags/r')
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -218,7 +218,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Pull down and build FluidSynth
         run: |
-          sudo apt-get build-dep fluidsynth2 --no-install-recommends
+          sudo apt-get build-dep fluidsynth --no-install-recommends
           git clone https://github.com/FluidSynth/fluidsynth.git
           cd fluidsynth
           mkdir build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -458,7 +458,7 @@ jobs:
           cp latest_rom/*.h src/.
       - name: Build Emulator
         run: |
-          TRACE=1 MAC_STATIC=1 ADDL_INCLUDE=/opt/homebrew/include HOMEBREW_LIB=/opt/homebew/lib make V=1 -j3
+          TRACE=1 MAC_STATIC=1 ADDL_INCLUDE=/opt/homebrew/include HOMEBREW_LIB=/opt/homebrew/lib make V=1 -j3
           mkdir emu_binaries
           cp sdcard.img.zip emu_binaries/.
           cp x16emu emu_binaries/.

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ ifdef EMSCRIPTEN
 	MAKECART_OUTPUT=makecart.html
 endif
 
-_X16_OBJS = cpu/fake6502.o memory.o disasm.o video.o i2c.o smc.o rtc.o via.o serial.o ieee.o vera_spi.o audio.o vera_pcm.o vera_psg.o sdcard.o main.o debugger.o javascript_interface.o joystick.o rendertext.o keyboard.o icon.o timing.o wav_recorder.o testbench.o files.o cartridge.o iso_8859_15.o ymglue.o
+_X16_OBJS = cpu/fake6502.o memory.o disasm.o video.o i2c.o smc.o rtc.o via.o serial.o ieee.o vera_spi.o audio.o vera_pcm.o vera_psg.o sdcard.o main.o debugger.o javascript_interface.o joystick.o rendertext.o keyboard.o icon.o timing.o wav_recorder.o testbench.o files.o cartridge.o iso_8859_15.o ymglue.o midi.o
 _X16_OBJS += extern/ymfm/src/ymfm_opm.o
 
 ifdef TARGET_WIN32

--- a/Makefile
+++ b/Makefile
@@ -43,10 +43,6 @@ GIT_REV=$(shell git diff --quiet && /bin/echo -n $$(git rev-parse --short=8 HEAD
 
 CFLAGS+=-D GIT_REV='"$(GIT_REV)"'
 
-ifdef FLUIDSYNTH_INCLUDE
-	CFLAGS+=-I$(FLUIDSYNTH_INCLUDE)
-endif
-
 ifeq ($(MAC_STATIC),1)
 	LDFLAGS=$(LIBSDL_FILE) -lm -liconv -lz -Wl,-framework,CoreAudio -Wl,-framework,AudioToolbox -Wl,-framework,ForceFeedback -lobjc -Wl,-framework,CoreVideo -Wl,-framework,Cocoa -Wl,-framework,Carbon -Wl,-framework,IOKit -Wl,-weak_framework,QuartzCore -Wl,-weak_framework,Metal -Wl,-weak_framework,CoreHaptics -Wl,-weak_framework,GameController
 endif

--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ ifdef EMSCRIPTEN
 	X16_OUTPUT=x16emu.html
 	MAKECART_OUTPUT=makecart.html
 else
-	FLUIDSYNTH_TEST=$(shell /usr/bin/printf '#include <fluidsynth.h>\nint main(){return 0;}' | $(CC) -x c -Wall -O -o /dev/null > /dev/null 2>/dev/null - && echo $$?)
+	FLUIDSYNTH_TEST=$(shell /usr/bin/printf '\043include <fluidsynth.h>\nint main(){return 0;} ' | $(CC) -x c -Wall -O -o /dev/null > /dev/null 2>/dev/null - && echo $$?)
 ifeq ($(FLUIDSYNTH_TEST),0)
 	CFLAGS+=-DHAS_FLUIDSYNTH
 endif

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,10 @@ ifndef NOLTO
 	LDFLAGS+=-flto
 endif
 
+ifdef ADDLINCLUDE
+	CFLAGS+=-I$(ADDLINCLUDE)
+endif
+
 X16_ODIR = build/x16emu
 X16_SDIR = src
 

--- a/Makefile
+++ b/Makefile
@@ -20,12 +20,6 @@ CFLAGS=-std=c99 -O3 -Wall -Werror -g $(shell $(SDL2CONFIG) --cflags) -Isrc/exter
 CXXFLAGS=-std=c++17 -O3 -Wall -Werror -Isrc/extern/ymfm/src
 LDFLAGS=$(shell $(SDL2CONFIG) --libs) -lm -lz -pthread
 
-# build with link time optimization
-ifndef NOLTO
-	CFLAGS+=-flto
-	LDFLAGS+=-flto
-endif
-
 ifdef ADDL_INCLUDE
 	CFLAGS+=-I$(ADDL_INCLUDE)
 endif
@@ -48,7 +42,7 @@ GIT_REV=$(shell git diff --quiet && /bin/echo -n $$(git rev-parse --short=8 HEAD
 CFLAGS+=-D GIT_REV='"$(GIT_REV)"'
 
 ifeq ($(MAC_STATIC),1)
-	LDFLAGS+=$(LIBSDL_FILE) -lm -liconv -lz -Wl,-framework,CoreAudio -Wl,-framework,AudioToolbox -Wl,-framework,ForceFeedback -lobjc -Wl,-framework,CoreVideo -Wl,-framework,Cocoa -Wl,-framework,Carbon -Wl,-framework,IOKit -Wl,-weak_framework,QuartzCore -Wl,-weak_framework,Metal -Wl,-weak_framework,CoreHaptics -Wl,-weak_framework,GameController
+	LDFLAGS=$(LIBSDL_FILE) -lm -liconv -lz -Wl,-framework,CoreAudio -Wl,-framework,AudioToolbox -Wl,-framework,ForceFeedback -lobjc -Wl,-framework,CoreVideo -Wl,-framework,Cocoa -Wl,-framework,Carbon -Wl,-framework,IOKit -Wl,-weak_framework,QuartzCore -Wl,-weak_framework,Metal -Wl,-weak_framework,CoreHaptics -Wl,-weak_framework,GameController -pthread
 	LDEMU=-ldl -Wl,-rpath,$(HOMEBREW_LIB)
 else ifeq ($(CROSS_COMPILE_WINDOWS),1)
 	LDFLAGS+=-L$(MINGW32)/lib
@@ -64,6 +58,12 @@ else
 endif
 else # Not Mac, not Windows, probably Linux
 	LDEMU=-ldl
+endif
+
+# build with link time optimization
+ifndef NOLTO
+	CFLAGS+=-flto
+	LDFLAGS+=-flto
 endif
 
 ifdef TARGET_WIN32

--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ ifdef EMSCRIPTEN
 	CFLAGS+=-s USE_ZLIB=1
 	X16_OUTPUT=x16emu.html
 	MAKECART_OUTPUT=makecart.html
-else ifeq "$(shell printf '#include <fluidsynth.h>\nint main(){return 0;}' | $(CC) -x c -Wall -O -o /dev/null > /dev/null 2>/dev/null - && echo $$? )" "0"
+else ifeq ($(shell printf '#include <fluidsynth.h>\nint main(){return 0;}' | $(CC) -x c -Wall -O -o /dev/null > /dev/null 2>/dev/null - && echo $$? ),0)
 	CFLAGS+=-DHAS_FLUIDSYNTH
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -48,13 +48,13 @@ GIT_REV=$(shell git diff --quiet && /bin/echo -n $$(git rev-parse --short=8 HEAD
 CFLAGS+=-D GIT_REV='"$(GIT_REV)"'
 
 ifeq ($(MAC_STATIC),1)
-	LDFLAGS=-L$(HOMEBREW_LIB) libSDL2.a libfluidsynth.a -lm -liconv -lz -Wl,-framework,CoreAudio -Wl,-framework,AudioToolbox -Wl,-framework,ForceFeedback -lobjc -Wl,-framework,CoreVideo -Wl,-framework,Cocoa -Wl,-framework,Carbon -Wl,-framework,IOKit -Wl,-weak_framework,QuartzCore -Wl,-weak_framework,Metal -Wl,-weak_framework,CoreHaptics -Wl,-weak_framework,GameController
+	LDFLAGS=-L$(HOMEBREW_LIB) -Wl,-Bstatic -lSDL2 -lfluidsynth -Wl,-Bdynamic -lm -liconv -lz -Wl,-framework,CoreAudio -Wl,-framework,AudioToolbox -Wl,-framework,ForceFeedback -lobjc -Wl,-framework,CoreVideo -Wl,-framework,Cocoa -Wl,-framework,Carbon -Wl,-framework,IOKit -Wl,-weak_framework,QuartzCore -Wl,-weak_framework,Metal -Wl,-weak_framework,CoreHaptics -Wl,-weak_framework,GameController
 else ifeq ($(CROSS_COMPILE_WINDOWS),1)
 	LDFLAGS+=-L$(MINGW32)/lib
 	# this enables printf() to show, but also forces a console window
 	LDFLAGS+=-Wl,--subsystem,console
 	LDFLAGS+=-static-libstdc++ -static-libgcc
-	LDFLAGS+=libSDL2.a libfluidsynth.a
+	LDFLAGS+=-Wl,-Bstatic -lSDL2 -lfluidsynth -Wl,-Bdynamic
 ifeq ($(TARGET_CPU),x86)
 	CC=i686-w64-mingw32-gcc
 	CXX=i686-w64-mingw32-g++

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ endif
 
 CFLAGS=-std=c99 -O3 -Wall -Werror -g $(shell $(SDL2CONFIG) --cflags) -Isrc/extern/include
 CXXFLAGS=-std=c++17 -O3 -Wall -Werror -Isrc/extern/ymfm/src
-LDFLAGS=$(shell $(SDL2CONFIG) --libs) -lm -lz
+LDFLAGS=$(shell $(SDL2CONFIG) --libs) -lm -lz -ldl
 
 # build with link time optimization
 ifndef NOLTO
@@ -42,6 +42,10 @@ MAKECART_OUTPUT=makecart
 GIT_REV=$(shell git diff --quiet && /bin/echo -n $$(git rev-parse --short=8 HEAD || /bin/echo "00000000") || /bin/echo -n $$( /bin/echo -n $$(git rev-parse --short=7 HEAD || /bin/echo "0000000"); /bin/echo -n '+'))
 
 CFLAGS+=-D GIT_REV='"$(GIT_REV)"'
+
+ifdef FLUIDSYNTH_INCLUDE
+	CFLAGS+=-I$(FLUIDSYNTH_INCLUDE)
+endif
 
 ifeq ($(MAC_STATIC),1)
 	LDFLAGS=$(LIBSDL_FILE) -lm -liconv -lz -Wl,-framework,CoreAudio -Wl,-framework,AudioToolbox -Wl,-framework,ForceFeedback -lobjc -Wl,-framework,CoreVideo -Wl,-framework,Cocoa -Wl,-framework,Carbon -Wl,-framework,IOKit -Wl,-weak_framework,QuartzCore -Wl,-weak_framework,Metal -Wl,-weak_framework,CoreHaptics -Wl,-weak_framework,GameController

--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,8 @@ ifdef EMSCRIPTEN
 	X16_OUTPUT=x16emu.html
 	MAKECART_OUTPUT=makecart.html
 else
-ifeq ($(shell /usr/bin/printf '#include <fluidsynth.h>\nint main(){return 0;}' | $(CC) -x c -Wall -O -o /dev/null - && echo $$?),0)
+	FLUIDSYNTH_TEST=$(shell /usr/bin/printf '#include <fluidsynth.h>\nint main(){return 0;}' | $(CC) -x c -Wall -O -o /dev/null > /dev/null 2>/dev/null - && echo $$?)
+ifeq ($(FLUIDSYNTH_TEST),0)
 	CFLAGS+=-DHAS_FLUIDSYNTH
 endif
 endif

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ GIT_REV=$(shell git diff --quiet && /bin/echo -n $$(git rev-parse --short=8 HEAD
 CFLAGS+=-D GIT_REV='"$(GIT_REV)"'
 
 ifeq ($(MAC_STATIC),1)
-	LDFLAGS=-L$(HOMEBREW_LIB) -Wl,-Bstatic -lSDL2 -lfluidsynth -Wl,-Bdynamic -lm -liconv -lz -Wl,-framework,CoreAudio -Wl,-framework,AudioToolbox -Wl,-framework,ForceFeedback -lobjc -Wl,-framework,CoreVideo -Wl,-framework,Cocoa -Wl,-framework,Carbon -Wl,-framework,IOKit -Wl,-weak_framework,QuartzCore -Wl,-weak_framework,Metal -Wl,-weak_framework,CoreHaptics -Wl,-weak_framework,GameController
+	LDFLAGS=$(HOMEBREW_LIB)/libSDL2.a $(HOMEBREW_LIB)/libfluidsynth.a -Wl,-Bdynamic -lm -liconv -lz -Wl,-framework,CoreAudio -Wl,-framework,AudioToolbox -Wl,-framework,ForceFeedback -lobjc -Wl,-framework,CoreVideo -Wl,-framework,Cocoa -Wl,-framework,Carbon -Wl,-framework,IOKit -Wl,-weak_framework,QuartzCore -Wl,-weak_framework,Metal -Wl,-weak_framework,CoreHaptics -Wl,-weak_framework,GameController
 else ifeq ($(CROSS_COMPILE_WINDOWS),1)
 	LDFLAGS+=-L$(MINGW32)/lib
 	# this enables printf() to show, but also forces a console window

--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,7 @@ ifeq ($(CROSS_COMPILE_WINDOWS),1)
 	# this enables printf() to show, but also forces a console window
 	LDFLAGS+=-Wl,--subsystem,console
 	LDFLAGS+=-static-libstdc++ -static-libgcc
+	LDFLAGS+=-lfluidsynth
 ifeq ($(TARGET_CPU),x86)
 	CC=i686-w64-mingw32-gcc
 	CXX=i686-w64-mingw32-g++

--- a/Makefile
+++ b/Makefile
@@ -48,14 +48,13 @@ GIT_REV=$(shell git diff --quiet && /bin/echo -n $$(git rev-parse --short=8 HEAD
 CFLAGS+=-D GIT_REV='"$(GIT_REV)"'
 
 ifeq ($(MAC_STATIC),1)
-	LDFLAGS=$(LIBSDL_FILE) -lm -liconv -lz -Wl,-framework,CoreAudio -Wl,-framework,AudioToolbox -Wl,-framework,ForceFeedback -lobjc -Wl,-framework,CoreVideo -Wl,-framework,Cocoa -Wl,-framework,Carbon -Wl,-framework,IOKit -Wl,-weak_framework,QuartzCore -Wl,-weak_framework,Metal -Wl,-weak_framework,CoreHaptics -Wl,-weak_framework,GameController
-endif
-
-ifeq ($(CROSS_COMPILE_WINDOWS),1)
+	LDFLAGS=-L$(HOMEBREW_LIB) libSDL2.a libfluidsynth.a -lm -liconv -lz -Wl,-framework,CoreAudio -Wl,-framework,AudioToolbox -Wl,-framework,ForceFeedback -lobjc -Wl,-framework,CoreVideo -Wl,-framework,Cocoa -Wl,-framework,Carbon -Wl,-framework,IOKit -Wl,-weak_framework,QuartzCore -Wl,-weak_framework,Metal -Wl,-weak_framework,CoreHaptics -Wl,-weak_framework,GameController
+else ifeq ($(CROSS_COMPILE_WINDOWS),1)
 	LDFLAGS+=-L$(MINGW32)/lib
 	# this enables printf() to show, but also forces a console window
 	LDFLAGS+=-Wl,--subsystem,console
 	LDFLAGS+=-static-libstdc++ -static-libgcc
+	LDFLAGS+=libSDL2.a libfluidsynth.a
 ifeq ($(TARGET_CPU),x86)
 	CC=i686-w64-mingw32-gcc
 	CXX=i686-w64-mingw32-g++
@@ -63,12 +62,13 @@ else
 	CC=x86_64-w64-mingw32-gcc
 	CXX=x86_64-w64-mingw32-g++
 endif
+else # Not Mac, not Windows, probably Linux
+	# Link static if possible, otherwise fall back to dynamic
+	LDFLAGS+=$(shell $(CC) -static -lfluidsynth &>/dev/null && /bin/echo "-Wl,-Bstatic -lfluidsynth -Wl,-Bdynamic" || /bin/echo "-lfluidsynth")
 endif
 
 ifdef TARGET_WIN32
 	LDFLAGS+=-ldwmapi
-else
-	LDFLAGS+=-ldl
 endif
 
 ifdef EMSCRIPTEN

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,6 @@ ifeq ($(CROSS_COMPILE_WINDOWS),1)
 	# this enables printf() to show, but also forces a console window
 	LDFLAGS+=-Wl,--subsystem,console
 	LDFLAGS+=-static-libstdc++ -static-libgcc
-	LDFLAGS+=-lfluidsynth
 ifeq ($(TARGET_CPU),x86)
 	CC=i686-w64-mingw32-gcc
 	CXX=i686-w64-mingw32-g++

--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ ifdef EMSCRIPTEN
 	X16_OUTPUT=x16emu.html
 	MAKECART_OUTPUT=makecart.html
 else
-ifeq ($(shell printf '#include <fluidsynth.h>\nint main(){return 0;}' | $(CC) -x c -Wall -O -o /dev/null > /dev/null 2>/dev/null - && echo $$?),0)
+ifeq ($(shell /usr/bin/printf '#include <fluidsynth.h>\nint main(){return 0;}' | $(CC) -x c -Wall -O -o /dev/null - && echo $$?),0)
 	CFLAGS+=-DHAS_FLUIDSYNTH
 endif
 endif

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ GIT_REV=$(shell git diff --quiet && /bin/echo -n $$(git rev-parse --short=8 HEAD
 CFLAGS+=-D GIT_REV='"$(GIT_REV)"'
 
 ifeq ($(MAC_STATIC),1)
-	LDFLAGS=$(shell for i in $$(brew deps --tree --installed fluid-synth | awk '{print $$NF}'); do brew list "$$i" | grep '.a$') $(HOMEBREW_LIB)/libSDL2.a -lm -liconv -lz -Wl,-framework,CoreAudio -Wl,-framework,AudioToolbox -Wl,-framework,ForceFeedback -lobjc -Wl,-framework,CoreVideo -Wl,-framework,Cocoa -Wl,-framework,Carbon -Wl,-framework,IOKit -Wl,-weak_framework,QuartzCore -Wl,-weak_framework,Metal -Wl,-weak_framework,CoreHaptics -Wl,-weak_framework,GameController
+	LDFLAGS=$(shell for i in $$(brew deps --tree --installed fluid-synth | awk '{print $$NF}'); do brew list "$$i" | grep '.a$$') $(HOMEBREW_LIB)/libSDL2.a -lm -liconv -lz -Wl,-framework,CoreAudio -Wl,-framework,AudioToolbox -Wl,-framework,ForceFeedback -lobjc -Wl,-framework,CoreVideo -Wl,-framework,Cocoa -Wl,-framework,Carbon -Wl,-framework,IOKit -Wl,-weak_framework,QuartzCore -Wl,-weak_framework,Metal -Wl,-weak_framework,CoreHaptics -Wl,-weak_framework,GameController
 else ifeq ($(CROSS_COMPILE_WINDOWS),1)
 	LDFLAGS+=-L$(MINGW32)/lib
 	# this enables printf() to show, but also forces a console window

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ GIT_REV=$(shell git diff --quiet && /bin/echo -n $$(git rev-parse --short=8 HEAD
 CFLAGS+=-D GIT_REV='"$(GIT_REV)"'
 
 ifeq ($(MAC_STATIC),1)
-	LDFLAGS=$(shell for i in $$(brew deps --tree --installed fluid-synth | awk '{print $$NF}'); do brew list "$$i" | grep '.a$$') $(HOMEBREW_LIB)/libSDL2.a -lm -liconv -lz -Wl,-framework,CoreAudio -Wl,-framework,AudioToolbox -Wl,-framework,ForceFeedback -lobjc -Wl,-framework,CoreVideo -Wl,-framework,Cocoa -Wl,-framework,Carbon -Wl,-framework,IOKit -Wl,-weak_framework,QuartzCore -Wl,-weak_framework,Metal -Wl,-weak_framework,CoreHaptics -Wl,-weak_framework,GameController
+	LDFLAGS=$(shell for i in $$(brew deps --tree --installed fluid-synth | awk '{print $$NF}'); do brew list "$$i" | grep '\.a$$'; done) $(HOMEBREW_LIB)/libSDL2.a -lm -liconv -lz -Wl,-framework,CoreAudio -Wl,-framework,AudioToolbox -Wl,-framework,ForceFeedback -lobjc -Wl,-framework,CoreVideo -Wl,-framework,Cocoa -Wl,-framework,Carbon -Wl,-framework,IOKit -Wl,-weak_framework,QuartzCore -Wl,-weak_framework,Metal -Wl,-weak_framework,CoreHaptics -Wl,-weak_framework,GameController
 else ifeq ($(CROSS_COMPILE_WINDOWS),1)
 	LDFLAGS+=-L$(MINGW32)/lib
 	# this enables printf() to show, but also forces a console window

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ else
 endif
 else # Not Mac, not Windows, probably Linux
 	# Link static if possible, otherwise fall back to dynamic
-	LDFLAGS+=$(shell $(CC) -static -lfluidsynth &>/dev/null && /bin/echo "-Wl,-Bstatic -lfluidsynth -Wl,-Bdynamic" || /bin/echo "-lfluidsynth")
+	LDFLUID=$(shell $(CC) -static -lfluidsynth &>/dev/null && /bin/echo "-Wl,-Bstatic -lfluidsynth -Wl,-Bdynamic" || /bin/echo "-lfluidsynth")
 endif
 
 ifdef TARGET_WIN32
@@ -99,7 +99,7 @@ MAKECART_DEPS := $(MAKECART_OBJS:.o=.d)
 all: x16emu makecart
 
 x16emu: $(X16_OBJS)
-	$(CXX) -o $(X16_OUTPUT) $(X16_OBJS) $(LDFLAGS)
+	$(CXX) -o $(X16_OUTPUT) $(X16_OBJS) $(LDFLAGS) $(LDFLUID)
 
 $(X16_ODIR)/%.o: $(X16_SDIR)/%.c
 	@mkdir -p $$(dirname $@)

--- a/Makefile
+++ b/Makefile
@@ -26,8 +26,8 @@ ifndef NOLTO
 	LDFLAGS+=-flto
 endif
 
-ifdef ADDLINCLUDE
-	CFLAGS+=-I$(ADDLINCLUDE)
+ifdef ADDL_INCLUDE
+	CFLAGS+=-I$(ADDL_INCLUDE)
 endif
 
 X16_ODIR = build/x16emu

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ GIT_REV=$(shell git diff --quiet && /bin/echo -n $$(git rev-parse --short=8 HEAD
 CFLAGS+=-D GIT_REV='"$(GIT_REV)"'
 
 ifeq ($(MAC_STATIC),1)
-	LDFLAGS=$(HOMEBREW_LIB)/libSDL2.a $(HOMEBREW_LIB)/libfluidsynth.a -Wl,-Bdynamic -lm -liconv -lz -Wl,-framework,CoreAudio -Wl,-framework,AudioToolbox -Wl,-framework,ForceFeedback -lobjc -Wl,-framework,CoreVideo -Wl,-framework,Cocoa -Wl,-framework,Carbon -Wl,-framework,IOKit -Wl,-weak_framework,QuartzCore -Wl,-weak_framework,Metal -Wl,-weak_framework,CoreHaptics -Wl,-weak_framework,GameController
+	LDFLAGS=$(HOMEBREW_LIB)/libSDL2.a $(HOMEBREW_LIB)/libfluidsynth.a -lm -liconv -lz -Wl,-framework,CoreAudio -Wl,-framework,AudioToolbox -Wl,-framework,ForceFeedback -lobjc -Wl,-framework,CoreVideo -Wl,-framework,Cocoa -Wl,-framework,Carbon -Wl,-framework,IOKit -Wl,-weak_framework,QuartzCore -Wl,-weak_framework,Metal -Wl,-weak_framework,CoreHaptics -Wl,-weak_framework,GameController
 else ifeq ($(CROSS_COMPILE_WINDOWS),1)
 	LDFLAGS+=-L$(MINGW32)/lib
 	# this enables printf() to show, but also forces a console window

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ endif
 
 CFLAGS=-std=c99 -O3 -Wall -Werror -g $(shell $(SDL2CONFIG) --cflags) -Isrc/extern/include
 CXXFLAGS=-std=c++17 -O3 -Wall -Werror -Isrc/extern/ymfm/src
-LDFLAGS=$(shell $(SDL2CONFIG) --libs) -lm -lz -ldl
+LDFLAGS=$(shell $(SDL2CONFIG) --libs) -lm -lz
 
 # build with link time optimization
 ifndef NOLTO
@@ -63,6 +63,8 @@ endif
 
 ifdef TARGET_WIN32
 	LDFLAGS+=-ldwmapi
+else
+	LDFLAGS+=-ldl
 endif
 
 ifdef EMSCRIPTEN

--- a/Makefile
+++ b/Makefile
@@ -77,8 +77,10 @@ ifdef EMSCRIPTEN
 	CFLAGS+=-s USE_ZLIB=1
 	X16_OUTPUT=x16emu.html
 	MAKECART_OUTPUT=makecart.html
-else ifeq ($(shell printf '#include <fluidsynth.h>\nint main(){return 0;}' | $(CC) -x c -Wall -O -o /dev/null > /dev/null 2>/dev/null - && echo $$? ),0)
+else
+ifeq ($(shell printf '#include <fluidsynth.h>\nint main(){return 0;}' | $(CC) -x c -Wall -O -o /dev/null > /dev/null 2>/dev/null - && echo $$? ),0)
 	CFLAGS+=-DHAS_FLUIDSYNTH
+endif
 endif
 
 _X16_OBJS = cpu/fake6502.o memory.o disasm.o video.o i2c.o smc.o rtc.o via.o serial.o ieee.o vera_spi.o audio.o vera_pcm.o vera_psg.o sdcard.o main.o debugger.o javascript_interface.o joystick.o rendertext.o keyboard.o icon.o timing.o wav_recorder.o testbench.o files.o cartridge.o iso_8859_15.o ymglue.o midi.o

--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,8 @@ ifdef EMSCRIPTEN
 	CFLAGS+=-s USE_ZLIB=1
 	X16_OUTPUT=x16emu.html
 	MAKECART_OUTPUT=makecart.html
+else ifeq "$(shell printf '#include <fluidsynth.h>\nint main(){return 0;}' | $(CC) -x c -Wall -O -o /dev/null > /dev/null 2>/dev/null - && echo $$? )" "0"
+	CFLAGS+=-DHAS_FLUIDSYNTH
 endif
 
 _X16_OBJS = cpu/fake6502.o memory.o disasm.o video.o i2c.o smc.o rtc.o via.o serial.o ieee.o vera_spi.o audio.o vera_pcm.o vera_psg.o sdcard.o main.o debugger.o javascript_interface.o joystick.o rendertext.o keyboard.o icon.o timing.o wav_recorder.o testbench.o files.o cartridge.o iso_8859_15.o ymglue.o midi.o

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ GIT_REV=$(shell git diff --quiet && /bin/echo -n $$(git rev-parse --short=8 HEAD
 CFLAGS+=-D GIT_REV='"$(GIT_REV)"'
 
 ifeq ($(MAC_STATIC),1)
-	LDFLAGS=$(HOMEBREW_LIB)/libSDL2.a $(HOMEBREW_LIB)/libfluidsynth.a -lm -liconv -lz -Wl,-framework,CoreAudio -Wl,-framework,AudioToolbox -Wl,-framework,ForceFeedback -lobjc -Wl,-framework,CoreVideo -Wl,-framework,Cocoa -Wl,-framework,Carbon -Wl,-framework,IOKit -Wl,-weak_framework,QuartzCore -Wl,-weak_framework,Metal -Wl,-weak_framework,CoreHaptics -Wl,-weak_framework,GameController
+	LDFLAGS=$(shell for i in $$(brew deps --tree --installed fluid-synth | awk '{print $$NF}'); do brew list "$$i" | grep '.a$') $(HOMEBREW_LIB)/libSDL2.a -lm -liconv -lz -Wl,-framework,CoreAudio -Wl,-framework,AudioToolbox -Wl,-framework,ForceFeedback -lobjc -Wl,-framework,CoreVideo -Wl,-framework,Cocoa -Wl,-framework,Carbon -Wl,-framework,IOKit -Wl,-weak_framework,QuartzCore -Wl,-weak_framework,Metal -Wl,-weak_framework,CoreHaptics -Wl,-weak_framework,GameController
 else ifeq ($(CROSS_COMPILE_WINDOWS),1)
 	LDFLAGS+=-L$(MINGW32)/lib
 	# this enables printf() to show, but also forces a console window

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ endif
 
 CFLAGS=-std=c99 -O3 -Wall -Werror -g $(shell $(SDL2CONFIG) --cflags) -Isrc/extern/include
 CXXFLAGS=-std=c++17 -O3 -Wall -Werror -Isrc/extern/ymfm/src
-LDFLAGS=$(shell $(SDL2CONFIG) --libs) -lm -lz
+LDFLAGS=$(shell $(SDL2CONFIG) --libs) -lm -lz -pthread
 
 # build with link time optimization
 ifndef NOLTO

--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ ifdef EMSCRIPTEN
 	X16_OUTPUT=x16emu.html
 	MAKECART_OUTPUT=makecart.html
 else
-ifeq ($(shell printf '#include <fluidsynth.h>\nint main(){return 0;}' | $(CC) -x c -Wall -O -o /dev/null > /dev/null 2>/dev/null - && echo $$? ),0)
+ifeq ($(shell printf '#include <fluidsynth.h>\nint main(){return 0;}' | $(CC) -x c -Wall -O -o /dev/null > /dev/null 2>/dev/null - && echo $$?),0)
 	CFLAGS+=-DHAS_FLUIDSYNTH
 endif
 endif

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ GIT_REV=$(shell git diff --quiet && /bin/echo -n $$(git rev-parse --short=8 HEAD
 CFLAGS+=-D GIT_REV='"$(GIT_REV)"'
 
 ifeq ($(MAC_STATIC),1)
-	LDFLAGS+=$(HOMEBREW_LIB)/libSDL2.a -lm -liconv -lz -Wl,-framework,CoreAudio -Wl,-framework,AudioToolbox -Wl,-framework,ForceFeedback -lobjc -Wl,-framework,CoreVideo -Wl,-framework,Cocoa -Wl,-framework,Carbon -Wl,-framework,IOKit -Wl,-weak_framework,QuartzCore -Wl,-weak_framework,Metal -Wl,-weak_framework,CoreHaptics -Wl,-weak_framework,GameController
+	LDFLAGS+=$(LIBSDL_FILE) -lm -liconv -lz -Wl,-framework,CoreAudio -Wl,-framework,AudioToolbox -Wl,-framework,ForceFeedback -lobjc -Wl,-framework,CoreVideo -Wl,-framework,Cocoa -Wl,-framework,Carbon -Wl,-framework,IOKit -Wl,-weak_framework,QuartzCore -Wl,-weak_framework,Metal -Wl,-weak_framework,CoreHaptics -Wl,-weak_framework,GameController
 	LDEMU=-ldl -Wl,-rpath,$(HOMEBREW_LIB)
 else ifeq ($(CROSS_COMPILE_WINDOWS),1)
 	LDFLAGS+=-L$(MINGW32)/lib
@@ -77,11 +77,10 @@ ifdef EMSCRIPTEN
 	CFLAGS+=-s USE_ZLIB=1
 	X16_OUTPUT=x16emu.html
 	MAKECART_OUTPUT=makecart.html
-else
-	FLUIDSYNTH_TEST=$(shell /usr/bin/printf '\043include <fluidsynth.h>\nint main(){return 0;} ' | $(CC) -x c -Wall -O -o /dev/null > /dev/null 2>/dev/null - && echo $$?)
-ifeq ($(FLUIDSYNTH_TEST),0)
-	CFLAGS+=-DHAS_FLUIDSYNTH
 endif
+
+ifeq ($(FLUIDSYNTH),1)
+	CFLAGS+=-DHAS_FLUIDSYNTH
 endif
 
 _X16_OBJS = cpu/fake6502.o memory.o disasm.o video.o i2c.o smc.o rtc.o via.o serial.o ieee.o vera_spi.o audio.o vera_pcm.o vera_psg.o sdcard.o main.o debugger.o javascript_interface.o joystick.o rendertext.o keyboard.o icon.o timing.o wav_recorder.o testbench.o files.o cartridge.o iso_8859_15.o ymglue.o midi.o

--- a/src/audio.c
+++ b/src/audio.c
@@ -380,9 +380,9 @@ audio_render()
 		}
 		// VERA+YM mixing is according to the Developer Board
 		// Loudest single PSG channel is 1/8 times the max output
-		// mix = (psg + pcm) * 2 + ym + fs
-		int32_t mix_l = (vera_out_l >> 13) + (ym_out_l >> 15) + (fs_out_l >> 13);
-		int32_t mix_r = (vera_out_r >> 13) + (ym_out_r >> 15) + (fs_out_r >> 13);
+		// mix = (psg + pcm) * 2 + ym + fs * 4
+		int32_t mix_l = (vera_out_l >> 13) + (ym_out_l >> 15) + (fs_out_l >> 12);
+		int32_t mix_r = (vera_out_r >> 13) + (ym_out_r >> 15) + (fs_out_r >> 12);
 		uint32_t amp = SDL_max(SDL_abs(mix_l), SDL_abs(mix_r));
 		if (amp > 32767) {
 			uint32_t limiter_amp_new = (32767 << 16) / amp;

--- a/src/cpu/registers.h
+++ b/src/cpu/registers.h
@@ -4,6 +4,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include "../endian.h"
 
 #define FLAG_CARRY     0x01
 #define FLAG_ZERO      0x02
@@ -19,26 +20,6 @@
 #define FLAG_CONSTANT FLAG_MEMORY_WIDTH
 
 //6502 CPU registers
-
-#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
-#define LOW_HIGH_UNION(name, low, high) \
-    union { \
-        struct { \
-            uint8_t low; \
-            uint8_t high; \
-        }; \
-        uint16_t name; \
-    }
-#else
-#define LOW_HIGH_UNION(name, low, high) \
-    union { \
-        struct { \
-            uint8_t high; \
-            uint8_t low; \
-        }; \
-        uint16_t name; \
-    }
-#endif
 
 struct regs
 {
@@ -58,8 +39,6 @@ struct regs
 
     bool is65c816;
 };
-
-#undef LOW_HIGH_UNION
 
 void increment_wrap_at_page_boundary(uint16_t *value);
 void decrement_wrap_at_page_boundary(uint16_t *value);

--- a/src/endian.h
+++ b/src/endian.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#define LOW_HIGH_UNION(name, low, high) \
+    union { \
+        struct { \
+            uint8_t low; \
+            uint8_t high; \
+        }; \
+        uint16_t name; \
+    }
+#else
+#define LOW_HIGH_UNION(name, low, high) \
+    union { \
+        struct { \
+            uint8_t high; \
+            uint8_t low; \
+        }; \
+        uint16_t name; \
+    }
+#endif

--- a/src/glue.h
+++ b/src/glue.h
@@ -79,6 +79,9 @@ extern bool has_via2;
 extern uint32_t host_sample_rate;
 extern bool enable_midline;
 
+extern bool has_midi_card;
+extern uint16_t midi_card_addr;
+
 extern void machine_dump(const char* reason);
 extern void machine_reset();
 extern void machine_nmi();

--- a/src/main.c
+++ b/src/main.c
@@ -670,7 +670,7 @@ main(int argc, char **argv)
 		} else if (!strcmp(argv[0], "-midi-in")) {
 			argc--;
 			argv++;
-			fs_midi_autoconnect = true;
+			fs_midi_in_connect = true;
 		} else if (!strcmp(argv[0], "-run")) {
 			argc--;
 			argv++;

--- a/src/main.c
+++ b/src/main.c
@@ -42,6 +42,7 @@
 #include "wav_recorder.h"
 #include "testbench.h"
 #include "cartridge.h"
+#include "midi.h"
 
 #ifdef __EMSCRIPTEN__
 #include <emscripten.h>
@@ -556,6 +557,7 @@ main(int argc, char **argv)
 	char *rom_path = rom_path_data;
 	char *prg_path = NULL;
 	char *bas_path = NULL;
+	char *sf2_path = NULL;
 	char *sdcard_path = NULL;
 	bool run_test = false;
 	int test_number = 0;
@@ -628,6 +630,15 @@ main(int argc, char **argv)
 				usage();
 			}
 			prg_path = argv[0];
+			argc--;
+			argv++;
+		} else if (!strcmp(argv[0], "-sf2")) {
+			argc--;
+			argv++;
+			if (!argc || argv[0][0] == '-') {
+				usage();
+			}
+			sf2_path = argv[0];
 			argc--;
 			argv++;
 		} else if (!strcmp(argv[0], "-run")) {
@@ -1086,6 +1097,11 @@ main(int argc, char **argv)
 #else
 		audio_buffers = 32;
 #endif
+	}
+
+	if (sf2_path) {
+		midi_init();
+		midi_load_sf2((uint8_t *)sf2_path);
 	}
 
 	if (cartridge_path) {

--- a/src/main.c
+++ b/src/main.c
@@ -537,11 +537,6 @@ usage()
 	printf("-sf2 <SoundFont filename>\n");
 	printf("\tInitialize MIDI synth with the specified SoundFont.\n");
 	printf("\tThe -midicard option must be specified along with this option.\n");
-	printf("-midi-in <device name/id>\n");
-	printf("\tConnect a specific system MIDI device to the virtualized MIDI card.\n");
-	printf("\tIf -midicard is set but this option is not, all MIDI input devices\n");
-	printf("\tare connected.\n");
-	printf("\tThe -midicard option must be specified along with this option.\n");
 #ifdef TRACE
 	printf("-trace [<address>]\n");
 	printf("\tPrint instruction trace. Optionally, a trigger address\n");
@@ -666,15 +661,6 @@ main(int argc, char **argv)
 				usage();
 			}
 			sf2_path = argv[0];
-			argc--;
-			argv++;
-		} else if (!strcmp(argv[0], "-midi-in")) {
-			argc--;
-			argv++;
-			if (!argc || argv[0][0] == '-') {
-				usage();
-			}
-			fs_midi_input_device = argv[0];
 			argc--;
 			argv++;
 		} else if (!strcmp(argv[0], "-run")) {

--- a/src/main.c
+++ b/src/main.c
@@ -333,6 +333,7 @@ machine_reset()
 	video_reset();
 	mouse_state_init();
 	reset6502(regs.is65c816);
+	midi_serial_init();
 }
 
 void
@@ -1602,6 +1603,8 @@ emulator_loop(void *param)
 		if (!headless) {
 			audio_step(clocks);
 		}
+
+		midi_serial_step(clocks);
 
 		if (!headless && new_frame) {
 			if (nvram_dirty && nvram_path) {

--- a/src/main.c
+++ b/src/main.c
@@ -538,7 +538,7 @@ usage()
 	printf("\tInitialize MIDI synth with the specified SoundFont.\n");
 	printf("\tThe -midicard option must be specified along with this option.\n");
 	printf("-midi-in\n");
-	printf("\tConnect the system MIDI input devices to the input of the first UART.\n");
+	printf("\tConnect the system MIDI input devices to the input of the first UART\n");
 	printf("\tof the emulated MIDI card. The -midicard option is required for this\n");
 	printf("\toption to have any effect.\n");
 #ifdef TRACE

--- a/src/main.c
+++ b/src/main.c
@@ -537,6 +537,10 @@ usage()
 	printf("-sf2 <SoundFont filename>\n");
 	printf("\tInitialize MIDI synth with the specified SoundFont.\n");
 	printf("\tThe -midicard option must be specified along with this option.\n");
+	printf("-midi-in\n");
+	printf("\tConnect the system MIDI input devices to the input of the first UART.\n");
+	printf("\tof the emulated MIDI card. The -midicard option is required for this\n");
+	printf("\toption to have any effect.\n");
 #ifdef TRACE
 	printf("-trace [<address>]\n");
 	printf("\tPrint instruction trace. Optionally, a trigger address\n");
@@ -663,6 +667,10 @@ main(int argc, char **argv)
 			sf2_path = argv[0];
 			argc--;
 			argv++;
+		} else if (!strcmp(argv[0], "-midi-in")) {
+			argc--;
+			argv++;
+			fs_midi_autoconnect = true;
 		} else if (!strcmp(argv[0], "-run")) {
 			argc--;
 			argv++;

--- a/src/main.c
+++ b/src/main.c
@@ -586,7 +586,8 @@ void no_fluidsynth_warning(void)
 		fprintf(stderr, "install the mingw-w64-i686-fluidsynth package before\n");
 		fprintf(stderr, "building x16emu.\n\n");
 #endif
-
+		fprintf(stderr, "Then build x16emu with FLUIDSYNTH=1. For example:\n");
+		fprintf(stderr, "FLUIDSYNTH=1 make\n");
 		already_warned = true;
 	}
 }

--- a/src/main.c
+++ b/src/main.c
@@ -537,6 +537,11 @@ usage()
 	printf("-sf2 <SoundFont filename>\n");
 	printf("\tInitialize MIDI synth with the specified SoundFont.\n");
 	printf("\tThe -midicard option must be specified along with this option.\n");
+	printf("-midi-in <device name/id>\n");
+	printf("\tConnect a specific system MIDI device to the virtualized MIDI card.\n");
+	printf("\tIf -midicard is set but this option is not, all MIDI input devices\n");
+	printf("\tare connected.\n");
+	printf("\tThe -midicard option must be specified along with this option.\n");
 #ifdef TRACE
 	printf("-trace [<address>]\n");
 	printf("\tPrint instruction trace. Optionally, a trigger address\n");
@@ -661,6 +666,15 @@ main(int argc, char **argv)
 				usage();
 			}
 			sf2_path = argv[0];
+			argc--;
+			argv++;
+		} else if (!strcmp(argv[0], "-midi-in")) {
+			argc--;
+			argv++;
+			if (!argc || argv[0][0] == '-') {
+				usage();
+			}
+			fs_midi_input_device = argv[0];
 			argc--;
 			argv++;
 		} else if (!strcmp(argv[0], "-run")) {

--- a/src/main.c
+++ b/src/main.c
@@ -562,6 +562,35 @@ usage_keymap()
 	exit(1);
 }
 
+void no_fluidsynth_warning(void)
+{
+	static bool already_warned;
+
+	if (!already_warned) {
+		fprintf(stderr, "\nWarning: x16emu was built without FluidSynth support,\n");
+		fprintf(stderr, "so the MIDI synth will be inoperative.\n\n");
+#if defined(__linux__)
+		fprintf(stderr, "To build x16emu with fluidsynth support, you distro may\n");
+		fprintf(stderr, "have a libfluidsynth-dev or fluidsynth-devel package that\n");
+		fprintf(stderr, "needs to be installed before building x16emu.\n\n");
+#elif defined(__APPLE__)
+		fprintf(stderr, "To build x16emu with fluidsynth support,\n");
+		fprintf(stderr, "install the homebrew package fluid-synth before\n");
+		fprintf(stderr, "building x16emu.\n\n");
+#elif defined(_WIN64)
+		fprintf(stderr, "To build x16emu with fluidsynth support under MSYS2,\n");
+		fprintf(stderr, "install the mingw-w64-x86_64-fluidsynth package before\n");
+		fprintf(stderr, "building x16emu.\n\n");
+#elif defined(_WIN32)
+		fprintf(stderr, "To build x16emu with fluidsynth support under MSYS2,\n");
+		fprintf(stderr, "install the mingw-w64-i686-fluidsynth package before\n");
+		fprintf(stderr, "building x16emu.\n\n");
+#endif
+
+		already_warned = true;
+	}
+}
+
 int
 main(int argc, char **argv)
 {
@@ -647,6 +676,9 @@ main(int argc, char **argv)
 			argc--;
 			argv++;
 		} else if (!strcmp(argv[0], "-midicard")) {
+#ifndef HAS_FLUIDSYNTH
+			no_fluidsynth_warning();
+#endif
 			argc--;
 			argv++;
 			has_midi_card = true;
@@ -659,6 +691,9 @@ main(int argc, char **argv)
 				midi_card_addr = 0x9f60;
 			}
 		} else if (!strcmp(argv[0], "-sf2")) {
+#ifndef HAS_FLUIDSYNTH
+			no_fluidsynth_warning();
+#endif
 			argc--;
 			argv++;
 			if (!argc || argv[0][0] == '-') {
@@ -668,6 +703,9 @@ main(int argc, char **argv)
 			argc--;
 			argv++;
 		} else if (!strcmp(argv[0], "-midi-in")) {
+#ifndef HAS_FLUIDSYNTH
+			no_fluidsynth_warning();
+#endif
 			argc--;
 			argv++;
 			fs_midi_in_connect = true;

--- a/src/memory.c
+++ b/src/memory.c
@@ -18,6 +18,7 @@
 #include "audio.h"
 #include "cartridge.h"
 #include "iso_8859_15.h"
+#include "midi.h"
 
 uint8_t ram_bank;
 uint8_t rom_bank;
@@ -197,6 +198,9 @@ real_read6502(uint16_t address, bool debugOn, int16_t bank)
 				return YM_read_status();
 			}
 			return 0x9f; // open bus read
+		} else if (address >= 0x9f60 && address < 0x9f70) {
+			// midi card
+			return midi_serial_read(address & 0x7, debugOn);
 		} else if (address >= 0x9fb0 && address < 0x9fc0) {
 			// emulator state
 			return emu_read(address & 0xf, debugOn);
@@ -274,6 +278,8 @@ write6502(uint16_t address, uint8_t value)
 				audio_render();
 				YM_write_reg(addr_ym, value);
 			}
+		} else if (address >= 0x9f60 && address < 0x9f70) {
+			midi_serial_write(address & 0x7, value);
 		} else if (address >= 0x9fb0 && address < 0x9fc0) {
 			// emulator state
 			emu_write(address & 0xf, value);

--- a/src/memory.c
+++ b/src/memory.c
@@ -198,12 +198,12 @@ real_read6502(uint16_t address, bool debugOn, int16_t bank)
 				return YM_read_status();
 			}
 			return 0x9f; // open bus read
-		} else if (address >= 0x9fc0 && address < 0x9fd0) {
-			// midi card
-			return midi_serial_read(address & 0xf, debugOn);
 		} else if (address >= 0x9fb0 && address < 0x9fc0) {
 			// emulator state
 			return emu_read(address & 0xf, debugOn);
+		} else if (has_midi_card && (address & 0xfff0) == midi_card_addr) {
+			// midi card
+			return midi_serial_read(address & 0xf, debugOn);
 		} else {
 			// future expansion
 			return 0x9f; // open bus read
@@ -278,11 +278,11 @@ write6502(uint16_t address, uint8_t value)
 				audio_render();
 				YM_write_reg(addr_ym, value);
 			}
-		} else if (address >= 0x9fc0 && address < 0x9fd0) {
-			midi_serial_write(address & 0xf, value);
 		} else if (address >= 0x9fb0 && address < 0x9fc0) {
 			// emulator state
 			emu_write(address & 0xf, value);
+		} else if (has_midi_card && (address & 0xfff0) == midi_card_addr) {
+			midi_serial_write(address & 0xf, value);
 		} else {
 			// future expansion
 		}

--- a/src/memory.c
+++ b/src/memory.c
@@ -198,7 +198,7 @@ real_read6502(uint16_t address, bool debugOn, int16_t bank)
 				return YM_read_status();
 			}
 			return 0x9f; // open bus read
-		} else if (address >= 0x9f60 && address < 0x9f70) {
+		} else if (address >= 0x9fc0 && address < 0x9fd0) {
 			// midi card
 			return midi_serial_read(address & 0xf, debugOn);
 		} else if (address >= 0x9fb0 && address < 0x9fc0) {
@@ -278,7 +278,7 @@ write6502(uint16_t address, uint8_t value)
 				audio_render();
 				YM_write_reg(addr_ym, value);
 			}
-		} else if (address >= 0x9f60 && address < 0x9f70) {
+		} else if (address >= 0x9fc0 && address < 0x9fd0) {
 			midi_serial_write(address & 0xf, value);
 		} else if (address >= 0x9fb0 && address < 0x9fc0) {
 			// emulator state

--- a/src/memory.c
+++ b/src/memory.c
@@ -200,7 +200,7 @@ real_read6502(uint16_t address, bool debugOn, int16_t bank)
 			return 0x9f; // open bus read
 		} else if (address >= 0x9f60 && address < 0x9f70) {
 			// midi card
-			return midi_serial_read(address & 0x7, debugOn);
+			return midi_serial_read(address & 0xf, debugOn);
 		} else if (address >= 0x9fb0 && address < 0x9fc0) {
 			// emulator state
 			return emu_read(address & 0xf, debugOn);
@@ -279,7 +279,7 @@ write6502(uint16_t address, uint8_t value)
 				YM_write_reg(addr_ym, value);
 			}
 		} else if (address >= 0x9f60 && address < 0x9f70) {
-			midi_serial_write(address & 0x7, value);
+			midi_serial_write(address & 0xf, value);
 		} else if (address >= 0x9fb0 && address < 0x9fc0) {
 			// emulator state
 			emu_write(address & 0xf, value);

--- a/src/midi.c
+++ b/src/midi.c
@@ -127,6 +127,7 @@ struct midi_serial_regs
 
 struct midi_serial_regs mregs[2];
 static bool serial_midi_mutexes_initialized = false;
+const char *fs_midi_input_device;
 
 void midi_serial_iir_check(uint8_t sel);
 
@@ -265,8 +266,18 @@ void midi_init()
     ASSIGN_FUNCTION(handle, dl_fluid_midi_event_get_velocity, "fluid_midi_event_get_velocity");
 
     fl_settings = dl_new_fluid_settings();
-    dl_fluid_settings_setnum(fl_settings, "synth.sample-rate", AUDIO_SAMPLERATE);
-    dl_fluid_settings_setint(fl_settings, "midi.autoconnect", 1);
+    dl_fluid_settings_setnum(fl_settings, "synth.sample-rate", 
+    AUDIO_SAMPLERATE);
+    dl_fluid_settings_setstr(fl_settings, "midi.portname", "Commander X16 Emulator");
+    if (fs_midi_input_device) {
+        dl_fluid_settings_setstr(fl_settings, "midi.winmidi.device", fs_midi_input_device);
+        dl_fluid_settings_setstr(fl_settings, "midi.alsa_seq.device", fs_midi_input_device);
+        dl_fluid_settings_setint(fl_settings, "midi.autoconnect", 0);
+    } else {
+        dl_fluid_settings_setstr(fl_settings, "midi.winmidi.device", "default");
+        dl_fluid_settings_setstr(fl_settings, "midi.alsa_seq.device", "default");
+        dl_fluid_settings_setint(fl_settings, "midi.autoconnect", 1);
+    }
     fl_synth = dl_new_fluid_synth(fl_settings);
     fl_mdriver = dl_new_fluid_midi_driver(fl_settings, handle_midi_event, &mregs[0]);
 
@@ -404,7 +415,7 @@ int handle_midi_event(void* data, fluid_midi_event_t* event)
 
     uint8_t type = dl_fluid_midi_event_get_type(event);
     uint8_t chan = dl_fluid_midi_event_get_channel(event);
-    uint8_t cmd = type | chan;
+    uint8_t cmd = (type < 0x80 || type >= 0xf0) ? type : (type | (chan & 0xf));
     uint8_t key, val;
 
     switch (type) {
@@ -454,7 +465,7 @@ int handle_midi_event(void* data, fluid_midi_event_t* event)
             break;
     }
 
-    fprintf(stderr, "Debug: MIDI IN: Type: %02X\n", type);
+    fprintf(stderr, "Debug: MIDI IN: Type: %02X Chan: %02X\n", type, chan);
 
     pthread_mutex_unlock(&mrp->fifo_mutex);
     return FLUID_OK;

--- a/src/midi.c
+++ b/src/midi.c
@@ -120,6 +120,7 @@ struct midi_serial_regs
 #undef LOW_HIGH_UNION
 
 struct midi_serial_regs mregs[2];
+static bool serial_midi_mutexes_initialized = false;
 
 #ifndef __EMSCRIPTEN__
 
@@ -131,7 +132,6 @@ static uint8_t midi_last_command = 0;
 static uint8_t midi_first_param;
 
 static bool midi_initialized = false;
-static bool serial_midi_mutexes_initialized = false;
 
 static fluid_settings_t* fl_settings;
 //static fluid_midi_driver_t* fl_mdriver;

--- a/src/midi.c
+++ b/src/midi.c
@@ -50,11 +50,75 @@ static fluid_audio_driver_t* fl_adriver;
 static fluid_synth_t* fl_synth;
 static int fl_sf2id;
 
+typedef fluid_settings_t* (*new_fluid_settings_f_t)(void);
+typedef fluid_synth_t* (*new_fluid_synth_f_t)(fluid_settings_t*);
+typedef fluid_audio_driver_t* (*new_fluid_audio_driver_f_t)(fluid_settings_t*, fluid_synth_t*);
+typedef int (*fluid_synth_sfload_f_t)(fluid_synth_t*,const char *,int);
+typedef int (*fluid_synth_program_change_f_t)(fluid_synth_t*, int, int);
+typedef int (*fluid_synth_channel_pressure_f_t)(fluid_synth_t*, int, int);
+typedef int (*fluid_synth_system_reset_f_t)(fluid_synth_t*);
+typedef int (*fluid_synth_noteoff_f_t)(fluid_synth_t*, int, int);
+typedef int (*fluid_synth_noteon_f_t)(fluid_synth_t*, int, int, int);
+typedef int (*fluid_synth_key_pressure_f_t)(fluid_synth_t*, int, int, int);
+typedef int (*fluid_synth_cc_f_t)(fluid_synth_t*, int, int, int);
+typedef int (*fluid_synth_pitch_bend_f_t)(fluid_synth_t*, int, int);
+typedef int (*fluid_synth_sysex_f_t)(fluid_synth_t*, const char*, int, char*, int*, int*, int);
+
+static new_fluid_settings_f_t dl_new_fluid_settings;
+static new_fluid_synth_f_t dl_new_fluid_synth;
+static new_fluid_audio_driver_f_t dl_new_fluid_audio_driver;
+static fluid_synth_sfload_f_t dl_fs_sfload;
+static fluid_synth_program_change_f_t dl_fs_program_change;
+static fluid_synth_channel_pressure_f_t dl_fs_channel_pressure;
+static fluid_synth_system_reset_f_t dl_fs_system_reset;
+static fluid_synth_noteoff_f_t dl_fs_noteoff;
+static fluid_synth_noteon_f_t dl_fs_noteon;
+static fluid_synth_key_pressure_f_t dl_fs_key_pressure;
+static fluid_synth_cc_f_t dl_fs_cc;
+static fluid_synth_pitch_bend_f_t dl_fs_pitch_bend;
+static fluid_synth_sysex_f_t dl_fs_sysex;
+
 void midi_init()
 {
-    fl_settings = new_fluid_settings();
-    fl_synth = new_fluid_synth(fl_settings);
-    fl_adriver = new_fluid_audio_driver(fl_settings, fl_synth);
+#ifdef _WIN32
+    LIBRARY_TYPE handle = LOAD_LIBRARY("libfluidsynth-3.dll");
+#elif __APPLE__
+    LIBRARY_TYPE handle = LOAD_LIBRARY("libfluidsynth.dylib");
+#else
+    LIBRARY_TYPE handle = LOAD_LIBRARY("libfluidsynth.so");
+#endif
+
+    if (!handle) {
+        // Handle the error on both platforms
+#ifdef _WIN32
+        fprintf(stderr, "Could not load MIDI synth library: error code %lu\n", GetLastError());
+#else
+        fprintf(stderr, "Could not load MIDI synth library: %s\n", dlerror());
+#endif
+        return;
+    }
+
+#ifndef _WIN32
+    dlerror();
+#endif
+
+    ASSIGN_FUNCTION(handle, dl_new_fluid_settings, "new_fluid_settings");
+    ASSIGN_FUNCTION(handle, dl_new_fluid_synth, "new_fluid_synth");
+    ASSIGN_FUNCTION(handle, dl_new_fluid_audio_driver, "new_fluid_audio_driver");
+    ASSIGN_FUNCTION(handle, dl_fs_sfload, "fluid_synth_sfload");
+    ASSIGN_FUNCTION(handle, dl_fs_program_change, "fluid_synth_program_change");
+    ASSIGN_FUNCTION(handle, dl_fs_channel_pressure, "fluid_synth_channel_pressure");
+    ASSIGN_FUNCTION(handle, dl_fs_system_reset, "fluid_synth_system_reset");
+    ASSIGN_FUNCTION(handle, dl_fs_noteoff, "fluid_synth_noteoff");
+    ASSIGN_FUNCTION(handle, dl_fs_noteon, "fluid_synth_noteon");
+    ASSIGN_FUNCTION(handle, dl_fs_key_pressure, "fluid_synth_key_pressure");
+    ASSIGN_FUNCTION(handle, dl_fs_cc, "fluid_synth_cc");
+    ASSIGN_FUNCTION(handle, dl_fs_pitch_bend, "fluid_synth_pitch_bend");
+    ASSIGN_FUNCTION(handle, dl_fs_sysex, "fluid_synth_sysex");
+
+    fl_settings = dl_new_fluid_settings();
+    fl_synth = dl_new_fluid_synth(fl_settings);
+    fl_adriver = dl_new_fluid_audio_driver(fl_settings, fl_synth);
 
     midi_initialized = true;
     printf("Initialized MIDI synth.\n");
@@ -63,7 +127,7 @@ void midi_init()
 void midi_load_sf2(uint8_t* filename)
 {
     if (!midi_initialized) return;
-    fl_sf2id = fluid_synth_sfload(fl_synth, (const char *)filename, true);
+    fl_sf2id = dl_fs_sfload(fl_synth, (const char *)filename, true);
     if (fl_sf2id == FLUID_FAILED) {
         printf("Unable to load soundfont.\n");
     }
@@ -79,9 +143,9 @@ void midi_byte(uint8_t b)
         case NORMAL:
             if (b < 0x80) {
                 if ((midi_last_command & 0xf0) == 0xc0) { // patch change
-                    fluid_synth_program_change(fl_synth, midi_last_command & 0xf, b);
+                    dl_fs_program_change(fl_synth, midi_last_command & 0xf, b);
                 } else if ((midi_last_command & 0xf0) == 0xd0) { // channel pressure
-                    fluid_synth_channel_pressure(fl_synth, midi_last_command & 0xf, b);
+                    dl_fs_channel_pressure(fl_synth, midi_last_command & 0xf, b);
                 } else if (midi_last_command >= 0x80) { // two-param command
                     midi_first_param = b;
                     midi_state = PARAM;
@@ -93,7 +157,7 @@ void midi_byte(uint8_t b)
                     sysex_bufptr = 0;
                     midi_state = SYSEX;
                 } else if (b == 0xff) {
-                    fluid_synth_system_reset(fl_synth);
+                    dl_fs_system_reset(fl_synth);
                     midi_last_command = 0;
                 }
             }
@@ -101,23 +165,23 @@ void midi_byte(uint8_t b)
         case PARAM:
             switch (midi_last_command & 0xf0) {
                 case 0x80: // note off
-                    fluid_synth_noteoff(fl_synth, midi_last_command & 0xf, midi_first_param); // no release velocity
+                    dl_fs_noteoff(fl_synth, midi_last_command & 0xf, midi_first_param); // no release velocity
                     break;
                 case 0x90: // note on
                     if (b == 0) {
-                        fluid_synth_noteoff(fl_synth, midi_last_command & 0xf, midi_first_param);
+                        dl_fs_noteoff(fl_synth, midi_last_command & 0xf, midi_first_param);
                     } else {
-                        fluid_synth_noteon(fl_synth, midi_last_command & 0xf, midi_first_param, b);
+                        dl_fs_noteon(fl_synth, midi_last_command & 0xf, midi_first_param, b);
                     }
                     break;
                 case 0xa0: // aftertouch
-                    fluid_synth_key_pressure(fl_synth, midi_last_command & 0xf, midi_first_param, b);
+                    dl_fs_key_pressure(fl_synth, midi_last_command & 0xf, midi_first_param, b);
                     break;
                 case 0xb0: // controller
-                    fluid_synth_cc(fl_synth, midi_last_command & 0xf, midi_first_param, b);
+                    dl_fs_cc(fl_synth, midi_last_command & 0xf, midi_first_param, b);
                     break;
                 case 0xe0: // pitch bend
-                    fluid_synth_pitch_bend(fl_synth, midi_last_command & 0xf, ((uint16_t)midi_first_param) | (uint16_t)b << 7);
+                    dl_fs_pitch_bend(fl_synth, midi_last_command & 0xf, ((uint16_t)midi_first_param) | (uint16_t)b << 7);
                     break;
             }
             midi_state = NORMAL;
@@ -125,7 +189,7 @@ void midi_byte(uint8_t b)
         case SYSEX:
             if (b == 0xf7) {
                 sysex_buffer[sysex_bufptr] = 0;
-                fluid_synth_sysex(fl_synth, (const char *)sysex_buffer, sysex_bufptr, NULL, NULL, NULL, 0);
+                dl_fs_sysex(fl_synth, (const char *)sysex_buffer, sysex_bufptr, NULL, NULL, NULL, 0);
                 midi_state = NORMAL;
             } else {
                 sysex_buffer[sysex_bufptr++] = b;

--- a/src/midi.c
+++ b/src/midi.c
@@ -218,7 +218,7 @@ void midi_init()
 #elif __APPLE__
     LIBRARY_TYPE handle = LOAD_LIBRARY("libfluidsynth.dylib");
 #else
-    LIBRARY_TYPE handle = LOAD_LIBRARY("libfluidsynth.so");
+    LIBRARY_TYPE handle = LOAD_LIBRARY("libfluidsynth.so.3");
 #endif
 
     if (!handle) {
@@ -453,6 +453,8 @@ int handle_midi_event(void* data, fluid_midi_event_t* event)
             midi_event_enqueue_byte(mrp, type);
             break;
     }
+
+    fprintf(stderr, "Debug: MIDI IN: Type: %02X\n", type);
 
     pthread_mutex_unlock(&mrp->fifo_mutex);
     return FLUID_OK;

--- a/src/midi.c
+++ b/src/midi.c
@@ -5,8 +5,6 @@
 #include "glue.h"
 #include "midi.h"
 
-#ifndef __EMSCRIPTEN__
-
 #ifdef _WIN32
     #include <windows.h>
     #define LIBRARY_TYPE HMODULE
@@ -32,14 +30,6 @@ enum MIDI_states {
     SYSEX,
 };
 
-static bool midi_initialized = false;
-
-static fluid_settings_t* fl_settings;
-//static fluid_midi_driver_t* fl_mdriver;
-static fluid_audio_driver_t* fl_adriver;
-static fluid_synth_t* fl_synth;
-static int fl_sf2id;
-
 static uint8_t sysex_buffer[1024];
 static int sysex_bufptr;
 
@@ -49,6 +39,16 @@ static uint8_t midi_first_param;
 
 static bool serial_dlab = false;
 static uint8_t serial_dll, serial_dlm, serial_spr;
+
+#ifndef __EMSCRIPTEN__
+
+static bool midi_initialized = false;
+
+static fluid_settings_t* fl_settings;
+//static fluid_midi_driver_t* fl_mdriver;
+static fluid_audio_driver_t* fl_adriver;
+static fluid_synth_t* fl_synth;
+static int fl_sf2id;
 
 typedef fluid_settings_t* (*new_fluid_settings_f_t)(void);
 typedef fluid_synth_t* (*new_fluid_synth_f_t)(fluid_settings_t*);

--- a/src/midi.c
+++ b/src/midi.c
@@ -127,7 +127,6 @@ struct midi_serial_regs
 
 struct midi_serial_regs mregs[2];
 static bool serial_midi_mutexes_initialized = false;
-const char *fs_midi_input_device;
 
 void midi_serial_iir_check(uint8_t sel);
 
@@ -269,15 +268,7 @@ void midi_init()
     dl_fluid_settings_setnum(fl_settings, "synth.sample-rate", 
     AUDIO_SAMPLERATE);
     dl_fluid_settings_setstr(fl_settings, "midi.portname", "Commander X16 Emulator");
-    if (fs_midi_input_device) {
-        dl_fluid_settings_setstr(fl_settings, "midi.winmidi.device", fs_midi_input_device);
-        dl_fluid_settings_setstr(fl_settings, "midi.alsa_seq.device", fs_midi_input_device);
-        dl_fluid_settings_setint(fl_settings, "midi.autoconnect", 0);
-    } else {
-        dl_fluid_settings_setstr(fl_settings, "midi.winmidi.device", "default");
-        dl_fluid_settings_setstr(fl_settings, "midi.alsa_seq.device", "default");
-        dl_fluid_settings_setint(fl_settings, "midi.autoconnect", 1);
-    }
+    dl_fluid_settings_setint(fl_settings, "midi.autoconnect", 1);
     fl_synth = dl_new_fluid_synth(fl_settings);
     fl_mdriver = dl_new_fluid_midi_driver(fl_settings, handle_midi_event, &mregs[0]);
 

--- a/src/midi.c
+++ b/src/midi.c
@@ -131,7 +131,7 @@ static bool serial_midi_mutexes_initialized = false;
 void midi_serial_iir_check(uint8_t sel);
 bool fs_midi_in_connect = false;
 
-#ifndef __EMSCRIPTEN__
+#ifdef HAS_FLUIDSYNTH
 
 int handle_midi_event(void* data, fluid_midi_event_t* event);
 
@@ -481,6 +481,12 @@ int handle_midi_event(void* data, fluid_midi_event_t* event)
             midi_event_enqueue_byte(mrp, type);
             break;
         case MIDI_SYSEX:
+            // FluidSynth doesn't offer a get_sysex function, but internally
+            // a text event is equivalent to a sysex event, in terms of what
+            // parts of the event structure are populated
+            //
+            // Unfortunately that means we have to fool it in order to
+            // access the data.
             dl_fluid_midi_event_set_type(event, MIDI_TEXT);
             if (dl_fluid_midi_event_get_text(event, (void **)&bufptr, &buflen) == FLUID_OK && bufptr != NULL) {
                 midi_event_enqueue_sysex(mrp, bufptr, buflen);

--- a/src/midi.c
+++ b/src/midi.c
@@ -8,7 +8,7 @@
 #ifdef _WIN32
     #include <windows.h>
     #define LIBRARY_TYPE HMODULE
-    #define LOAD_LIBRARY(name) LoadLibrary(name)
+    #define LOAD_LIBRARY(name) LoadLibraryEx(name, NULL, LOAD_LIBRARY_SEARCH_APPLICATION_DIR)
     #define GET_FUNCTION(lib, name) GetProcAddress(lib, name)
     #define CLOSE_LIBRARY(lib) FreeLibrary(lib)
 #else
@@ -81,13 +81,11 @@ static fluid_synth_sysex_f_t dl_fs_sysex;
 void midi_init()
 {
 
-    LIBRARY_TYPE handle = LOAD_LIBRARY(
 #ifdef _WIN32
-        "libfluidsynth-3.dll"
+    LIBRARY_TYPE handle = LOAD_LIBRARY("libfluidsynth-3.dll")
 #else
-        "libfluidsynth.so"
+    LIBRARY_TYPE handle = LOAD_LIBRARY("libfluidsynth.so")
 #endif
-    );
 
     if (!handle) {
         // Handle the error on both platforms
@@ -98,6 +96,10 @@ void midi_init()
 #endif
         return;
     }
+
+#ifndef _WIN32
+    dlerror();
+#endif
 
     ASSIGN_FUNCTION(handle, dl_new_fluid_settings, "new_fluid_settings");
     ASSIGN_FUNCTION(handle, dl_new_fluid_synth, "new_fluid_synth");

--- a/src/midi.c
+++ b/src/midi.c
@@ -82,9 +82,9 @@ void midi_init()
 {
 
 #ifdef _WIN32
-    LIBRARY_TYPE handle = LOAD_LIBRARY("libfluidsynth-3.dll")
+    LIBRARY_TYPE handle = LOAD_LIBRARY("libfluidsynth-3.dll");
 #else
-    LIBRARY_TYPE handle = LOAD_LIBRARY("libfluidsynth.so")
+    LIBRARY_TYPE handle = LOAD_LIBRARY("libfluidsynth.so");
 #endif
 
     if (!handle) {

--- a/src/midi.c
+++ b/src/midi.c
@@ -83,6 +83,8 @@ void midi_init()
 
 #ifdef _WIN32
     LIBRARY_TYPE handle = LOAD_LIBRARY("libfluidsynth-3.dll");
+#elif __APPLE__
+    LIBRARY_TYPE handle = LOAD_LIBRARY("libfluidsynth.dylib");
 #else
     LIBRARY_TYPE handle = LOAD_LIBRARY("libfluidsynth.so");
 #endif

--- a/src/midi.c
+++ b/src/midi.c
@@ -2,6 +2,7 @@
 // Copyright (c) 2024 MooingLemur
 // All rights reserved. License: 2-clause BSD
 
+#include <pthread.h>
 #include "glue.h"
 #include "midi.h"
 
@@ -30,8 +31,95 @@ enum MIDI_states {
     SYSEX,
 };
 
-static bool serial_dlab = false;
-static uint8_t serial_dll, serial_dlm, serial_spr;
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#define LOW_HIGH_UNION(name, low, high) \
+    union { \
+        struct { \
+            uint8_t low; \
+            uint8_t high; \
+        }; \
+        uint16_t name; \
+    }
+#else
+#define LOW_HIGH_UNION(name, low, high) \
+    union { \
+        struct { \
+            uint8_t high; \
+            uint8_t low; \
+        }; \
+        uint16_t name; \
+    }
+#endif
+
+struct midi_serial_regs
+{
+    LOW_HIGH_UNION(dl, dll, dlm);
+
+    bool ier_erbi;
+    bool ier_etbei;
+    bool ier_elsi;
+    bool ier_edssi;
+
+    uint8_t iir;
+
+    bool fcr_fifo_enable;
+    uint8_t fcr_ififo_trigger_level_bytes;
+
+    uint8_t lcr_word_length_bits;
+    bool lcr_stb;
+    bool lcr_pen;
+    bool lcr_eps;
+    bool lcr_stick;
+    bool lcr_break;
+    bool lcr_dlab;
+
+    bool mcr_dtr;
+    bool mcr_rts;
+    bool mcr_out1;
+    bool mcr_out2;
+    bool mcr_loop;
+    bool mcr_afe;
+
+    bool lsr_oe;
+    bool lsr_pe;
+    bool lsr_fe;
+    bool lsr_bi;
+    bool lsr_eif;
+
+    bool msr_dcts;
+    bool msr_ddsr;
+    bool msr_teri;
+    bool msr_ddcd;
+    bool msr_cts;
+    bool msr_dsr;
+    bool msr_ri;
+    bool msr_dcd;
+
+    uint8_t obyte_bits_remain;
+    uint8_t rx_timeout;
+    bool rx_timeout_enabled;
+
+    bool thre_intr;
+    uint8_t thre_bits_remain;
+
+    uint8_t scratch;
+    uint8_t ififo[16];
+    uint8_t ifsz;
+    uint8_t ofifo[16];
+    uint8_t ofsz;
+
+    int64_t clock; // 40.24 fixed point
+    int32_t clockdec; // 8.24 fixed point
+
+    time_t last_warning;
+
+    pthread_mutex_t fifo_mutex;
+    pthread_mutexattr_t fifo_mutex_attr;
+};
+
+#undef LOW_HIGH_UNION
+
+struct midi_serial_regs mregs[2];
 
 #ifndef __EMSCRIPTEN__
 
@@ -43,6 +131,7 @@ static uint8_t midi_last_command = 0;
 static uint8_t midi_first_param;
 
 static bool midi_initialized = false;
+static bool serial_midi_mutexes_initialized = false;
 
 static fluid_settings_t* fl_settings;
 //static fluid_midi_driver_t* fl_mdriver;
@@ -80,6 +169,10 @@ static fluid_synth_sysex_f_t dl_fs_sysex;
 
 void midi_init()
 {
+    if (midi_initialized) {
+        return;
+    }
+
 #ifdef _WIN32
     LIBRARY_TYPE handle = LOAD_LIBRARY("libfluidsynth-3.dll");
 #elif __APPLE__
@@ -138,7 +231,6 @@ void midi_load_sf2(uint8_t* filename)
 void midi_byte(uint8_t b)
 {
     if (!midi_initialized) return;
-
     switch (midi_state) {
         case NORMAL:
             if (b < 0x80) {
@@ -188,11 +280,18 @@ void midi_byte(uint8_t b)
             break;
         case SYSEX:
             if (b == 0xf7) {
-                sysex_buffer[sysex_bufptr] = 0;
-                dl_fs_sysex(fl_synth, (const char *)sysex_buffer, sysex_bufptr, NULL, NULL, NULL, 0);
+                if (sysex_bufptr < (sizeof(sysex_buffer) / sizeof(sysex_buffer[0]))-1) { // only if buffer didn't fill
+                    sysex_buffer[sysex_bufptr] = 0;
+                    dl_fs_sysex(fl_synth, (const char *)sysex_buffer, sysex_bufptr, NULL, NULL, NULL, 0);
+                }
                 midi_state = NORMAL;
             } else {
-                sysex_buffer[sysex_bufptr++] = b;
+                sysex_buffer[sysex_bufptr] = b;
+                // we can't do much about a runaway sysex other than continue to absorb it
+                // but we throw it all away later if the buffer filled
+                if (sysex_bufptr < (sizeof(sysex_buffer) / sizeof(sysex_buffer[0]))-1) {
+                    sysex_bufptr++;
+                }
             }
             break;
     }
@@ -206,93 +305,384 @@ void midi_load_sf2(uint8_t* filename)
 
 void midi_init()
 {
-    printf("No fluidsynth support on WebAssembly.\n");
+    fprintf(stderr, "No FluidSynth support.\n");
 }
 
-void midi_byte(uint8_t b) {
+void midi_byte(uint8_t b)
+{
     // no-op
 }
 
 #endif
 
+void midi_serial_init()
+{
+    uint8_t sel;
 
-uint8_t midi_serial_read(uint8_t reg, bool debugOn) {
+    for (sel=0; sel<2; sel++) {
+        mregs[sel].ier_erbi = false;
+        mregs[sel].ier_etbei = false;
+        mregs[sel].ier_elsi = false;
+        mregs[sel].ier_edssi = false;
+
+        mregs[sel].iir = 0x01;
+
+        mregs[sel].fcr_fifo_enable = false;
+        mregs[sel].fcr_ififo_trigger_level_bytes = 1;
+
+        mregs[sel].lcr_word_length_bits = 5;
+        mregs[sel].lcr_stb = false;
+        mregs[sel].lcr_pen = false;
+        mregs[sel].lcr_eps = false;
+        mregs[sel].lcr_stick = false;
+        mregs[sel].lcr_break = false;
+        mregs[sel].lcr_dlab = false;
+
+        mregs[sel].mcr_dtr = false;
+        mregs[sel].mcr_rts = false;
+        mregs[sel].mcr_out1 = false;
+        mregs[sel].mcr_out2 = false;
+        mregs[sel].mcr_loop = false;
+        mregs[sel].mcr_afe = false;
+
+        mregs[sel].lsr_oe = false;
+        mregs[sel].lsr_pe = false;
+        mregs[sel].lsr_fe = false;
+        mregs[sel].lsr_bi = false;
+        mregs[sel].lsr_eif = false;
+
+        mregs[sel].msr_dcts = false;
+        mregs[sel].msr_ddsr = false;
+        mregs[sel].msr_teri = false;
+        mregs[sel].msr_ddcd = false;
+
+        mregs[sel].msr_cts = false;
+        mregs[sel].msr_dsr = false;
+        mregs[sel].msr_ri = false;
+        mregs[sel].msr_dcd = false;
+
+        mregs[sel].obyte_bits_remain = 0;
+        mregs[sel].rx_timeout = 0;
+        mregs[sel].rx_timeout_enabled = false;
+        mregs[sel].thre_intr = false;
+        mregs[sel].thre_bits_remain = 0;
+
+        mregs[sel].ifsz = 0;
+        mregs[sel].ofsz = 0;
+        mregs[sel].clock = 0;
+        mregs[sel].clockdec = 0;
+        mregs[sel].last_warning = 0;
+
+    }
+
+    if (!serial_midi_mutexes_initialized) {
+        for (sel=0; sel<2; sel++) {
+            pthread_mutexattr_init(&mregs[sel].fifo_mutex_attr);
+            pthread_mutex_init(&mregs[sel].fifo_mutex, &mregs[sel].fifo_mutex_attr);
+        }
+        serial_midi_mutexes_initialized = true;
+    }
+}
+
+void midi_serial_step(int clocks)
+{
+    uint8_t sel, i;
+    for (sel=0; sel<2; sel++) {
+        mregs[sel].clock -= (int64_t)mregs[sel].clockdec * clocks;
+        while (mregs[sel].clock < 0) {
+            // process uart
+            pthread_mutex_lock(&mregs[sel].fifo_mutex);
+            if (mregs[sel].obyte_bits_remain > 0) {
+                mregs[sel].obyte_bits_remain--;
+            }
+            if (mregs[sel].ofsz > 0) {
+                if (mregs[sel].obyte_bits_remain == 0) {
+                    if (sel == 1) {
+                        midi_byte(mregs[sel].ofifo[0]);
+                    }
+                    mregs[sel].ofsz--;
+                    if (mregs[sel].ofsz > 0) {
+                        for (i=0; i<mregs[sel].ofsz; i++) {
+                            mregs[sel].ofifo[i] = mregs[sel].ofifo[i+1];
+                        }
+                    } else if (mregs[sel].thre_bits_remain == 0) {
+                        mregs[sel].thre_intr = true;
+                    }
+                    mregs[sel].obyte_bits_remain = 2 + mregs[sel].lcr_word_length_bits + mregs[sel].lcr_stb + mregs[sel].lcr_pen;
+                }
+            } else {
+                if (mregs[sel].thre_bits_remain > 0) {
+                    mregs[sel].thre_bits_remain--;
+                    if (mregs[sel].thre_bits_remain == 0) {
+                        mregs[sel].thre_intr = true;
+                    }
+                }
+            }
+            pthread_mutex_unlock(&mregs[sel].fifo_mutex);
+            mregs[sel].clock += 0x1000000LL;
+        }
+    }
+}
+
+void midi_serial_enqueue_obyte(uint8_t sel, uint8_t val) {
+    pthread_mutex_lock(&mregs[sel].fifo_mutex);
+    if (mregs[sel].ofsz < (mregs[sel].fcr_fifo_enable ? 16 : 1)) {
+        mregs[sel].ofifo[mregs[sel].ofsz] = val;
+        mregs[sel].thre_intr = false;
+        mregs[sel].ofsz++;
+        if (mregs[sel].ofsz == 1) { // We were empty
+            if (mregs[sel].fcr_fifo_enable) {
+                // We delay a bit longer to reraise the THRE interrupt if we're coming from 0
+                mregs[sel].thre_bits_remain = 1 + mregs[sel].lcr_word_length_bits + mregs[sel].lcr_stb + mregs[sel].lcr_pen;
+            }
+        } else {
+            mregs[sel].thre_bits_remain = 0;
+        }
+    } else {
+        printf("TX Overflow\n");
+    }
+    pthread_mutex_unlock(&mregs[sel].fifo_mutex);
+}
+
+void midi_serial_iir_check(uint8_t sel) {
+    uint8_t fifoen = (uint8_t)mregs[sel].fcr_fifo_enable << 6 | (uint8_t)mregs[sel].fcr_fifo_enable << 7;
+    if (mregs[sel].ier_elsi && (mregs[sel].lsr_oe || mregs[sel].lsr_pe || mregs[sel].lsr_fe || mregs[sel].lsr_bi)) {
+        mregs[sel].iir = (0x06 | fifoen); // Receiver line status interrupt
+    } else if (mregs[sel].ier_erbi && !mregs[sel].fcr_fifo_enable && mregs[sel].ifsz > 0) {
+        mregs[sel].iir = (0x04 | fifoen); // Received data available interrupt (16450 mode)
+    } else if (mregs[sel].ier_erbi && mregs[sel].fcr_fifo_enable && mregs[sel].ifsz >= mregs[sel].fcr_ififo_trigger_level_bytes) {
+        mregs[sel].iir = (0x04 | fifoen); // Received data available interrupt (16550 mode)
+    } else if (mregs[sel].ier_erbi && mregs[sel].fcr_fifo_enable && mregs[sel].ifsz > 0 && mregs[sel].rx_timeout_enabled && mregs[sel].rx_timeout == 0) {
+        mregs[sel].iir = (0x0c | fifoen); // Received data available interrupt (timeout, 16550 mode)
+    } else if (mregs[sel].ier_etbei && mregs[sel].thre_intr) {
+        mregs[sel].iir = (0x02 | fifoen); // Transmitter holding register empty interrupt
+    } else if (mregs[sel].ier_edssi && ((!mregs[sel].mcr_afe && mregs[sel].msr_dcts) || mregs[sel].msr_ddcd || mregs[sel].msr_ddsr || mregs[sel].msr_teri)) {
+        mregs[sel].iir = (0x00 | fifoen); // Modem status register interrupt
+    } else {
+        mregs[sel].iir = (0x01 | fifoen); // no interrupt waiting
+    }
+}
+
+uint8_t midi_serial_read(uint8_t reg, bool debugOn)
+{
     //printf("midi_serial_read %d\n", reg);
-    switch (reg) {
+    uint8_t sel = (reg & 8) >> 3;
+    switch (reg & 7) {
         case 0x0:
-            if (serial_dlab) {
-                return serial_dll;
+            if (mregs[sel].lcr_dlab) {
+                return mregs[sel].dll;
             } else {
                 // TODO: RHR
             }
             break;
         case 0x1:
-            if (serial_dlab) {
-                return serial_dlm;
+            if (mregs[sel].lcr_dlab) {
+                return mregs[sel].dlm;
+            } else {
+                return (((uint8_t)mregs[sel].ier_edssi << 3) |
+                        ((uint8_t)mregs[sel].ier_elsi << 2) |
+                        ((uint8_t)mregs[sel].ier_etbei << 1) |
+                        ((uint8_t)mregs[sel].ier_erbi));
             }
-            return 0x00;
-            // TODO: IER
             break;
-        case 0x2:
-            return 0x00;
-            // TODO: ISR
+        case 0x2: {
+            uint8_t ret = mregs[sel].iir;
+            if (!debugOn) {
+                mregs[sel].thre_intr = false;
+                midi_serial_iir_check(sel);
+            }
+            return ret;
             break;
+        }
         case 0x3:
-            return 0x03 | ((int)serial_dlab << 7);
-            // TODO: rest of LCR
+            return (((uint8_t)mregs[sel].lcr_dlab << 7) |
+                    ((uint8_t)mregs[sel].lcr_break << 6) |
+                    ((uint8_t)mregs[sel].lcr_stick << 5) |
+                    ((uint8_t)mregs[sel].lcr_eps << 4) |
+                    ((uint8_t)mregs[sel].lcr_pen << 3) |
+                    ((uint8_t)mregs[sel].lcr_stb << 2) |
+                    ((mregs[sel].lcr_word_length_bits - 5) & 0x3));
             break;
         case 0x4:
-            return 0x03;
-            // TODO: MCR
+            return (((uint8_t)mregs[sel].mcr_afe << 5) |
+                    ((uint8_t)mregs[sel].mcr_loop << 4) |
+                    ((uint8_t)mregs[sel].mcr_out2 << 3) |
+                    ((uint8_t)mregs[sel].mcr_out1 << 2) |
+                    ((uint8_t)mregs[sel].mcr_rts << 1) |
+                    ((uint8_t)mregs[sel].mcr_dtr));
             break;
-        case 0x5:
-            return 0x20;
-            // TODO: LSR
+        case 0x5: {
+            uint8_t ret = (((uint8_t)mregs[sel].lsr_eif << 7) |
+                    ((uint8_t)(mregs[sel].obyte_bits_remain == 0 && mregs[sel].ofsz == 0) << 6) |
+                    ((uint8_t)(mregs[sel].ofsz == 0) << 5) |
+                    ((uint8_t)mregs[sel].lsr_bi << 4) |
+                    ((uint8_t)mregs[sel].lsr_fe << 3) |
+                    ((uint8_t)mregs[sel].lsr_pe << 2) |
+                    ((uint8_t)mregs[sel].lsr_oe << 1) |
+                    ((uint8_t)(mregs[sel].ifsz > 0)));
+            if (!debugOn) {
+                mregs[sel].lsr_oe = false;
+                mregs[sel].lsr_pe = false;
+                mregs[sel].lsr_fe = false;
+                mregs[sel].lsr_bi = false;
+            }
+            return ret;
             break;
+        }
         case 0x6:
-            return 0x00;
-            // TODO: MSR
+            return (((uint8_t)mregs[sel].msr_dcd << 7) |
+                    ((uint8_t)mregs[sel].msr_ri << 6) |
+                    ((uint8_t)mregs[sel].msr_dsr << 5) |
+                    ((uint8_t)mregs[sel].msr_cts << 4) |
+                    ((uint8_t)mregs[sel].msr_ddcd << 3) |
+                    ((uint8_t)mregs[sel].msr_teri << 2) |
+                    ((uint8_t)mregs[sel].msr_ddsr << 1) |
+                    ((uint8_t)mregs[sel].msr_dcts));
             break;
         case 0x7:
-            return serial_spr;
+            return mregs[sel].scratch;
             break;
     }
     return 0x00;
 }
 
-void midi_serial_write(uint8_t reg, uint8_t val) {
+void midi_serial_calculate_clk(uint8_t sel)
+{
+    double uart_clks_per_cpu = (MIDI_UART_OSC_RATE_MHZ / MIDI_UART_PRIMARY_DIVIDER) / MHZ;
+    if (mregs[sel].dl > 0) {
+        uart_clks_per_cpu /= mregs[sel].dl;
+        mregs[sel].clockdec = uart_clks_per_cpu * 0x1000000L; // convert to 8.24 fixed point
+    } else {
+        mregs[sel].clockdec = 0;
+    }
+}
+
+void midi_serial_write(uint8_t reg, uint8_t val)
+{
     //printf("midi_serial_write %d %d\n", reg, val);
-    switch (reg) {
+    uint8_t sel = (reg & 8) >> 3;
+    switch (reg & 7) {
         case 0x0:
-            if (serial_dlab) {
-                serial_dll = val;
+            if (mregs[sel].lcr_dlab) {
+                mregs[sel].dll = val;
+                midi_serial_calculate_clk(sel);
             } else {
-                midi_byte((uint8_t)val);
+                if (mregs[sel].lcr_word_length_bits != 8 || mregs[sel].lcr_stb || mregs[sel].lcr_pen || mregs[sel].lcr_eps || mregs[sel].lcr_stick || mregs[sel].lcr_break) {
+                    if (mregs[sel].last_warning + 60 < time(NULL)) {
+                        unsigned char par = 'N';
+                        if (mregs[sel].lcr_pen) {
+                            switch ((uint8_t)(mregs[sel].lcr_eps << 1) | (uint8_t)mregs[sel].lcr_stick) {
+                                case 0:
+                                    par = 'O';
+                                    break;
+                                case 1:
+                                    par = 'M';
+                                    break;
+                                case 2:
+                                    par = 'E';
+                                    break;
+                                case 3:
+                                    par = 'S';
+                                    break;
+                            }
+                        }
+                        fprintf(stderr, "Serial MIDI: Warning: improper LCR %d%c%d for UART %d, must be set to 8N1.\n", mregs[sel].lcr_word_length_bits, par, 1+(uint8_t)mregs[sel].lcr_stb, sel);
+                        mregs[sel].last_warning = time(NULL);
+                    }
+                } else if (mregs[sel].dl != 32 && mregs[sel].last_warning + 60 < time(NULL)) {
+                    fprintf(stderr, "Serial MIDI: Warning: improper divisor %d for UART %d, must be set to 32 for standard MIDI bitrate.\n", mregs[sel].dl, sel);
+                    mregs[sel].last_warning = time(NULL);
+                } else {
+                    midi_serial_enqueue_obyte(sel, val);
+                }
             }
             break;
         case 0x1:
-            if (serial_dlab) {
-                serial_dlm = val;
+            if (mregs[sel].lcr_dlab) {
+                mregs[sel].dlm = val;
+                midi_serial_calculate_clk(sel);
+            } else {
+                mregs[sel].ier_erbi = !!(val & 1);
+                mregs[sel].ier_etbei = !!(val & 2);
+                mregs[sel].ier_elsi = !!(val & 4);
+                mregs[sel].ier_edssi = !!(val & 8);
             }
-            // TODO: IER
             break;
         case 0x2:
-            // TODO: FCR
+            if (val & 1) {
+                mregs[sel].fcr_fifo_enable = true;
+                switch ((val & 0xc0) >> 6) {
+                    case 0:
+                        mregs[sel].fcr_ififo_trigger_level_bytes = 1;
+                        break;
+                    case 1:
+                        mregs[sel].fcr_ififo_trigger_level_bytes = 4;
+                        break;
+                    case 2:
+                        mregs[sel].fcr_ififo_trigger_level_bytes = 8;
+                        break;
+                    case 3:
+                        mregs[sel].fcr_ififo_trigger_level_bytes = 14;
+                        break;
+                }
+            } else {
+                mregs[sel].fcr_fifo_enable = false;
+                mregs[sel].fcr_ififo_trigger_level_bytes = 1;
+            }
+            if (val & 2) {
+                mregs[sel].ifsz = 0;
+            }
+            if (val & 4) {
+                mregs[sel].ofsz = 0;
+            }
+            if (mregs[sel].thre_bits_remain == 0) { 
+                mregs[sel].thre_intr = true;
+            }
+            midi_serial_iir_check(sel);
             break;
         case 0x3:
-            serial_dlab = (bool)(val >> 7);
-            // TODO: rest of LCR
+            mregs[sel].lcr_word_length_bits = (val & 0x03)+5;
+            mregs[sel].lcr_stb = !!(val & 0x04);
+            mregs[sel].lcr_pen = !!(val & 0x08);
+            mregs[sel].lcr_eps = !!(val & 0x10);
+            mregs[sel].lcr_stick = !!(val & 0x20);
+            mregs[sel].lcr_break = !!(val & 0x40);
+            mregs[sel].lcr_dlab = !!(val & 0x80);
             break;
         case 0x4:
-            // TODO: MCR
-            break;
-        case 0x5:
-            if (serial_dlab) {
-                // TODO: PSD
+            mregs[sel].mcr_dtr = !!(val & 0x01);
+            mregs[sel].mcr_rts = !!(val & 0x02);
+            mregs[sel].mcr_out1 = !!(val & 0x04);
+            mregs[sel].mcr_out2 = !!(val & 0x08);
+            mregs[sel].mcr_loop = !!(val & 0x10);
+            mregs[sel].mcr_afe = !!(val & 0x20);
+
+            if (mregs[sel].mcr_loop) {
+                mregs[sel].msr_dcts |= mregs[sel].msr_cts ^ mregs[sel].mcr_dtr;
+                mregs[sel].msr_cts = mregs[sel].mcr_dtr;
+
+                mregs[sel].msr_ddsr |= mregs[sel].msr_dsr ^ mregs[sel].mcr_rts;
+                mregs[sel].msr_dsr = mregs[sel].mcr_rts;
+
+                if (mregs[sel].msr_ri) {
+                    mregs[sel].msr_teri |= mregs[sel].msr_ri ^ mregs[sel].mcr_out1;
+                }
+                mregs[sel].msr_ri = mregs[sel].mcr_out1;
+
+                mregs[sel].msr_ddcd |= mregs[sel].msr_dcd ^ mregs[sel].mcr_out2;
+                mregs[sel].msr_dcd = mregs[sel].mcr_out2;
+
+            } else {
+                // DTR tied to RI on opposite UART, wired this way on the official X16 MIDI card
+                if (mregs[sel ^ 1].msr_ri && !mregs[sel].mcr_dtr) {
+                    mregs[sel ^ 1].msr_teri = true;
+                }
+                mregs[sel ^ 1].msr_ri = mregs[sel].mcr_dtr;
             }
+
             break;
         case 0x7:
-            serial_spr = val;
+            mregs[sel].scratch = val;
             break;
     }
 }

--- a/src/midi.c
+++ b/src/midi.c
@@ -7,10 +7,6 @@
 
 #ifdef _WIN32
     #include <windows.h>
-    #define LIBRARY_TYPE HMODULE
-    #define LOAD_LIBRARY(name) LoadLibraryEx(name, NULL, LOAD_LIBRARY_SEARCH_APPLICATION_DIR)
-    #define GET_FUNCTION(lib, name) GetProcAddress(lib, name)
-    #define CLOSE_LIBRARY(lib) FreeLibrary(lib)
 #else
     #include <dlfcn.h>
     #define LIBRARY_TYPE void*
@@ -20,7 +16,7 @@
 #endif
 
 #define ASSIGN_FUNCTION(lib, var, name) {\
-    var = (void *)GET_FUNCTION(lib, name);\
+    var = GET_FUNCTION(lib, name);\
     if (!var) { fprintf(stderr, "Unable to find symbol for '%s'\n", name); CLOSE_LIBRARY(handle); return; }\
 }
 
@@ -82,24 +78,27 @@ void midi_init()
 {
 
 #ifdef _WIN32
-    LIBRARY_TYPE handle = LOAD_LIBRARY("libfluidsynth-3.dll");
+    dl_new_fluid_settings = new_fluid_settings;
+    dl_new_fluid_synth = new_fluid_synth;
+    dl_fs_sfload = fluid_synth_sfload;
+    dl_fs_program_change = fluid_synth_program_change;
+    dl_fs_channel_pressure = fluid_synth_channel_pressure;
+    dl_fs_system_reset = fluid_synth_system_reset;
+    dl_fs_noteoff = fluid_synth_noteoff;
+    dl_fs_noteon = fluid_synth_noteon;
+    dl_fs_key_pressure = fluid_synth_key_pressure;
+    dl_fs_cc = fluid_synth_cc;
+    dl_fs_pitch_bend = fluid_synth_pitch_bend;
+    dl_fs_sysex = fluid_synth_sysex;
 #else
     LIBRARY_TYPE handle = LOAD_LIBRARY("libfluidsynth.so");
-#endif
 
     if (!handle) {
-        // Handle the error on both platforms
-#ifdef _WIN32
-        fprintf(stderr, "Could not load MIDI synth library: error code %lu\n", GetLastError());
-#else
         fprintf(stderr, "Could not load MIDI synth library: %s\n", dlerror());
-#endif
         return;
     }
 
-#ifndef _WIN32
     dlerror();
-#endif
 
     ASSIGN_FUNCTION(handle, dl_new_fluid_settings, "new_fluid_settings");
     ASSIGN_FUNCTION(handle, dl_new_fluid_synth, "new_fluid_synth");
@@ -114,6 +113,7 @@ void midi_init()
     ASSIGN_FUNCTION(handle, dl_fs_cc, "fluid_synth_cc");
     ASSIGN_FUNCTION(handle, dl_fs_pitch_bend, "fluid_synth_pitch_bend");
     ASSIGN_FUNCTION(handle, dl_fs_sysex, "fluid_synth_sysex");
+#endif
 
     fl_settings = dl_new_fluid_settings();
     fl_synth = dl_new_fluid_synth(fl_settings);

--- a/src/midi.c
+++ b/src/midi.c
@@ -1,0 +1,296 @@
+// Commander X16 Emulator
+// Copyright (c) 2024 MooingLemur
+// All rights reserved. License: 2-clause BSD
+
+#include "glue.h"
+#include "midi.h"
+
+#ifndef __EMSCRIPTEN__
+
+#ifdef _WIN32
+    #include <windows.h>
+    #define LIBRARY_TYPE HMODULE
+    #define LOAD_LIBRARY(name) LoadLibrary(name)
+    #define GET_FUNCTION(lib, name) GetProcAddress(lib, name)
+    #define CLOSE_LIBRARY(lib) FreeLibrary(lib)
+#else
+    #include <dlfcn.h>
+    #define LIBRARY_TYPE void*
+    #define LOAD_LIBRARY(name) dlopen(name, RTLD_LAZY)
+    #define GET_FUNCTION(lib, name) dlsym(lib, name)
+    #define CLOSE_LIBRARY(lib) dlclose(lib)
+#endif
+
+#define ASSIGN_FUNCTION(lib, var, name) {\
+    var = GET_FUNCTION(lib, name);\
+    if (!var) { fprintf(stderr, "Unable to find symbol for '%s'\n", name); CLOSE_LIBRARY(handle); return; }\
+}
+
+enum MIDI_states {
+    NORMAL,
+    PARAM,
+    SYSEX,
+};
+
+static bool midi_initialized = false;
+
+static fluid_settings_t* fl_settings;
+//static fluid_midi_driver_t* fl_mdriver;
+static fluid_audio_driver_t* fl_adriver;
+static fluid_synth_t* fl_synth;
+static int fl_sf2id;
+
+static uint8_t sysex_buffer[1024];
+static int sysex_bufptr;
+
+static enum MIDI_states midi_state = NORMAL;
+static uint8_t midi_last_command = 0;
+static uint8_t midi_first_param;
+
+static bool serial_dlab = false;
+static uint8_t serial_dll, serial_dlm, serial_spr;
+
+typedef fluid_settings_t* (*new_fluid_settings_f_t)(void);
+typedef fluid_synth_t* (*new_fluid_synth_f_t)(fluid_settings_t*);
+typedef fluid_audio_driver_t* (*new_fluid_audio_driver_f_t)(fluid_settings_t*, fluid_synth_t*);
+typedef int (*fluid_synth_sfload_f_t)(fluid_synth_t*,const char *,int);
+typedef int (*fluid_synth_program_change_f_t)(fluid_synth_t*, int, int);
+typedef int (*fluid_synth_channel_pressure_f_t)(fluid_synth_t*, int, int);
+typedef int (*fluid_synth_system_reset_f_t)(fluid_synth_t*);
+typedef int (*fluid_synth_noteoff_f_t)(fluid_synth_t*, int, int);
+typedef int (*fluid_synth_noteon_f_t)(fluid_synth_t*, int, int, int);
+typedef int (*fluid_synth_key_pressure_f_t)(fluid_synth_t*, int, int, int);
+typedef int (*fluid_synth_cc_f_t)(fluid_synth_t*, int, int, int);
+typedef int (*fluid_synth_pitch_bend_f_t)(fluid_synth_t*, int, int);
+typedef int (*fluid_synth_sysex_f_t)(fluid_synth_t*, const char*, int, char*, int*, int*, int);
+
+static new_fluid_settings_f_t dl_new_fluid_settings;
+static new_fluid_synth_f_t dl_new_fluid_synth;
+static new_fluid_audio_driver_f_t dl_new_fluid_audio_driver;
+static fluid_synth_sfload_f_t dl_fs_sfload;
+static fluid_synth_program_change_f_t dl_fs_program_change;
+static fluid_synth_channel_pressure_f_t dl_fs_channel_pressure;
+static fluid_synth_system_reset_f_t dl_fs_system_reset;
+static fluid_synth_noteoff_f_t dl_fs_noteoff;
+static fluid_synth_noteon_f_t dl_fs_noteon;
+static fluid_synth_key_pressure_f_t dl_fs_key_pressure;
+static fluid_synth_cc_f_t dl_fs_cc;
+static fluid_synth_pitch_bend_f_t dl_fs_pitch_bend;
+static fluid_synth_sysex_f_t dl_fs_sysex;
+
+void midi_init()
+{
+
+    LIBRARY_TYPE handle = LOAD_LIBRARY(
+#ifdef _WIN32
+        "fluidsynth.dll"
+#else
+        "libfluidsynth.so"
+#endif
+    );
+
+    if (!handle) {
+        // Handle the error on both platforms
+#ifdef _WIN32
+        fprintf(stderr, "Could not load MIDI synth library: error code %lu\n", GetLastError());
+#else
+        fprintf(stderr, "Could not load MIDI synth library: %s\n", dlerror());
+#endif
+        return;
+    }
+
+    ASSIGN_FUNCTION(handle, dl_new_fluid_settings, "new_fluid_settings");
+    ASSIGN_FUNCTION(handle, dl_new_fluid_synth, "new_fluid_synth");
+    ASSIGN_FUNCTION(handle, dl_new_fluid_audio_driver, "new_fluid_audio_driver");
+    ASSIGN_FUNCTION(handle, dl_fs_sfload, "fluid_synth_sfload");
+    ASSIGN_FUNCTION(handle, dl_fs_program_change, "fluid_synth_program_change");
+    ASSIGN_FUNCTION(handle, dl_fs_channel_pressure, "fluid_synth_channel_pressure");
+    ASSIGN_FUNCTION(handle, dl_fs_system_reset, "fluid_synth_system_reset");
+    ASSIGN_FUNCTION(handle, dl_fs_noteoff, "fluid_synth_noteoff");
+    ASSIGN_FUNCTION(handle, dl_fs_noteon, "fluid_synth_noteon");
+    ASSIGN_FUNCTION(handle, dl_fs_key_pressure, "fluid_synth_key_pressure");
+    ASSIGN_FUNCTION(handle, dl_fs_cc, "fluid_synth_cc");
+    ASSIGN_FUNCTION(handle, dl_fs_pitch_bend, "fluid_synth_pitch_bend");
+    ASSIGN_FUNCTION(handle, dl_fs_sysex, "fluid_synth_sysex");
+
+    fl_settings = dl_new_fluid_settings();
+    fl_synth = dl_new_fluid_synth(fl_settings);
+    fl_adriver = dl_new_fluid_audio_driver(fl_settings, fl_synth);
+
+    midi_initialized = true;
+    printf("FLUID INIT\n");
+}
+
+void midi_load_sf2(uint8_t* filename)
+{
+    if (!midi_initialized) return;
+    fl_sf2id = dl_fs_sfload(fl_synth, (const char *)filename, true);
+    if (fl_sf2id == FLUID_FAILED) {
+        printf("Unable to load soundfont.\n");
+    }
+}
+
+// Receive a byte from client
+// Store state, or dispatch event
+void midi_byte(uint8_t b)
+{
+    if (!midi_initialized) return;
+
+    switch (midi_state) {
+        case NORMAL:
+            if (b < 0x80) {
+                if ((midi_last_command & 0xf0) == 0xc0) { // patch change
+                    dl_fs_program_change(fl_synth, midi_last_command & 0xf, b);
+                } else if ((midi_last_command & 0xf0) == 0xd0) { // channel pressure
+                    dl_fs_channel_pressure(fl_synth, midi_last_command & 0xf, b);
+                } else if (midi_last_command >= 0x80) { // two-param command
+                    midi_first_param = b;
+                    midi_state = PARAM;
+                }
+            } else {
+                if (b < 0xf0) {
+                    midi_last_command = b;
+                } else if (b == 0xf0) {
+                    sysex_bufptr = 0;
+                    midi_state = SYSEX;
+                } else if (b == 0xff) {
+                    dl_fs_system_reset(fl_synth);
+                    midi_last_command = 0;
+                }
+            }
+            break;
+        case PARAM:
+            switch (midi_last_command & 0xf0) {
+                case 0x80: // note off
+                    dl_fs_noteoff(fl_synth, midi_last_command & 0xf, midi_first_param); // no release velocity
+                    break;
+                case 0x90: // note on
+                    if (b == 0) {
+                        dl_fs_noteoff(fl_synth, midi_last_command & 0xf, midi_first_param);
+                    } else {
+                        dl_fs_noteon(fl_synth, midi_last_command & 0xf, midi_first_param, b);
+                    }
+                    break;
+                case 0xa0: // aftertouch
+                    dl_fs_key_pressure(fl_synth, midi_last_command & 0xf, midi_first_param, b);
+                    break;
+                case 0xb0: // controller
+                    dl_fs_cc(fl_synth, midi_last_command & 0xf, midi_first_param, b);
+                    break;
+                case 0xe0: // pitch bend
+                    dl_fs_pitch_bend(fl_synth, midi_last_command & 0xf, ((uint16_t)midi_first_param) | (uint16_t)b << 7);
+                    break;
+            }
+            midi_state = NORMAL;
+            break;
+        case SYSEX:
+            if (b == 0xf7) {
+                sysex_buffer[sysex_bufptr] = 0;
+                dl_fs_sysex(fl_synth, (const char *)sysex_buffer, sysex_bufptr, NULL, NULL, NULL, 0);
+                midi_state = NORMAL;
+            } else {
+                sysex_buffer[sysex_bufptr++] = b;
+            }
+            break;
+    }
+}
+
+#else
+void midi_load_sf2(uint8_t* filename)
+{
+    // no-op
+}
+
+void midi_init()
+{
+    printf("No fluidsynth support on WebAssembly.\n");
+}
+
+void midi_byte(uint8_t b) {
+    // no-op
+}
+
+#endif
+
+
+uint8_t midi_serial_read(uint8_t reg, bool debugOn) {
+    //printf("midi_serial_read %d\n", reg);
+    switch (reg) {
+        case 0x0:
+            if (serial_dlab) {
+                return serial_dll;
+            } else {
+                // TODO: RHR
+            }
+            break;
+        case 0x1:
+            if (serial_dlab) {
+                return serial_dlm;
+            }
+            return 0x00;
+            // TODO: IER
+            break;
+        case 0x2:
+            return 0x00;
+            // TODO: ISR
+            break;
+        case 0x3:
+            return 0x03 | ((int)serial_dlab << 7);
+            // TODO: rest of LCR
+            break;
+        case 0x4:
+            return 0x03;
+            // TODO: MCR
+            break;
+        case 0x5:
+            return 0x20;
+            // TODO: LSR
+            break;
+        case 0x6:
+            return 0x00;
+            // TODO: MSR
+            break;
+        case 0x7:
+            return serial_spr;
+            break;
+    }
+    return 0x00;
+}
+
+void midi_serial_write(uint8_t reg, uint8_t val) {
+    //printf("midi_serial_write %d %d\n", reg, val);
+    switch (reg) {
+        case 0x0:
+            if (serial_dlab) {
+                serial_dll = val;
+            } else {
+                midi_byte((uint8_t)val);
+            }
+            break;
+        case 0x1:
+            if (serial_dlab) {
+                serial_dlm = val;
+            }
+            // TODO: IER
+            break;
+        case 0x2:
+            // TODO: FCR
+            break;
+        case 0x3:
+            serial_dlab = (bool)(val >> 7);
+            // TODO: rest of LCR
+            break;
+        case 0x4:
+            // TODO: MCR
+            break;
+        case 0x5:
+            if (serial_dlab) {
+                // TODO: PSD
+            }
+            break;
+        case 0x7:
+            serial_spr = val;
+            break;
+    }
+}
+

--- a/src/midi.c
+++ b/src/midi.c
@@ -20,7 +20,7 @@
 #endif
 
 #define ASSIGN_FUNCTION(lib, var, name) {\
-    var = GET_FUNCTION(lib, name);\
+    (void *)var = (void *)GET_FUNCTION(lib, name);\
     if (!var) { fprintf(stderr, "Unable to find symbol for '%s'\n", name); CLOSE_LIBRARY(handle); return; }\
 }
 
@@ -30,17 +30,17 @@ enum MIDI_states {
     SYSEX,
 };
 
+static bool serial_dlab = false;
+static uint8_t serial_dll, serial_dlm, serial_spr;
+
+#ifndef __EMSCRIPTEN__
+
 static uint8_t sysex_buffer[1024];
 static int sysex_bufptr;
 
 static enum MIDI_states midi_state = NORMAL;
 static uint8_t midi_last_command = 0;
 static uint8_t midi_first_param;
-
-static bool serial_dlab = false;
-static uint8_t serial_dll, serial_dlm, serial_spr;
-
-#ifndef __EMSCRIPTEN__
 
 static bool midi_initialized = false;
 

--- a/src/midi.c
+++ b/src/midi.c
@@ -305,7 +305,11 @@ void midi_byte(uint8_t b)
 }
 
 void midi_synth_render(int16_t* buf, int len) {
-    dl_fs_write_s16(fl_synth, len, buf, 0, 2, buf, 1, 2);
+    if (midi_initialized) {
+        dl_fs_write_s16(fl_synth, len, buf, 0, 2, buf, 1, 2);
+    } else {
+        memset(buf, 0, len * 2 * sizeof(int16_t));
+    }
 }
 
 #else

--- a/src/midi.c
+++ b/src/midi.c
@@ -129,6 +129,7 @@ struct midi_serial_regs mregs[2];
 static bool serial_midi_mutexes_initialized = false;
 
 void midi_serial_iir_check(uint8_t sel);
+bool fs_midi_autoconnect = false;
 
 #ifndef __EMSCRIPTEN__
 
@@ -268,7 +269,7 @@ void midi_init()
     dl_fluid_settings_setnum(fl_settings, "synth.sample-rate", 
     AUDIO_SAMPLERATE);
     dl_fluid_settings_setstr(fl_settings, "midi.portname", "Commander X16 Emulator");
-    dl_fluid_settings_setint(fl_settings, "midi.autoconnect", 1);
+    dl_fluid_settings_setint(fl_settings, "midi.autoconnect", fs_midi_autoconnect);
     fl_synth = dl_new_fluid_synth(fl_settings);
     fl_mdriver = dl_new_fluid_midi_driver(fl_settings, handle_midi_event, &mregs[0]);
 

--- a/src/midi.c
+++ b/src/midi.c
@@ -128,10 +128,11 @@ struct midi_serial_regs
 struct midi_serial_regs mregs[2];
 static bool serial_midi_mutexes_initialized = false;
 
+void midi_serial_iir_check(uint8_t sel);
+
 #ifndef __EMSCRIPTEN__
 
 int handle_midi_event(void* data, fluid_midi_event_t* event);
-void midi_serial_iir_check(uint8_t sel);
 
 static uint8_t sysex_buffer[1024];
 static int sysex_bufptr;

--- a/src/midi.c
+++ b/src/midi.c
@@ -20,7 +20,7 @@
 #endif
 
 #define ASSIGN_FUNCTION(lib, var, name) {\
-    (void *)var = (void *)GET_FUNCTION(lib, name);\
+    var = (void *)GET_FUNCTION(lib, name);\
     if (!var) { fprintf(stderr, "Unable to find symbol for '%s'\n", name); CLOSE_LIBRARY(handle); return; }\
 }
 

--- a/src/midi.c
+++ b/src/midi.c
@@ -129,7 +129,7 @@ struct midi_serial_regs mregs[2];
 static bool serial_midi_mutexes_initialized = false;
 
 void midi_serial_iir_check(uint8_t sel);
-bool fs_midi_autoconnect = false;
+bool fs_midi_in_connect = false;
 
 #ifndef __EMSCRIPTEN__
 
@@ -269,9 +269,11 @@ void midi_init()
     dl_fluid_settings_setnum(fl_settings, "synth.sample-rate", 
     AUDIO_SAMPLERATE);
     dl_fluid_settings_setstr(fl_settings, "midi.portname", "Commander X16 Emulator");
-    dl_fluid_settings_setint(fl_settings, "midi.autoconnect", fs_midi_autoconnect);
+    dl_fluid_settings_setint(fl_settings, "midi.autoconnect", fs_midi_in_connect);
     fl_synth = dl_new_fluid_synth(fl_settings);
-    fl_mdriver = dl_new_fluid_midi_driver(fl_settings, handle_midi_event, &mregs[0]);
+    if (fs_midi_in_connect) {
+        fl_mdriver = dl_new_fluid_midi_driver(fl_settings, handle_midi_event, &mregs[0]);
+    }
 
     midi_initialized = true;
     fprintf(stderr, "Initialized MIDI synth at $%04X.\n", midi_card_addr);

--- a/src/midi.c
+++ b/src/midi.c
@@ -83,7 +83,7 @@ void midi_init()
 
     LIBRARY_TYPE handle = LOAD_LIBRARY(
 #ifdef _WIN32
-        "fluidsynth.dll"
+        "libfluidsynth-3.dll"
 #else
         "libfluidsynth.so"
 #endif

--- a/src/midi.c
+++ b/src/midi.c
@@ -130,6 +130,8 @@ static bool serial_midi_mutexes_initialized = false;
 
 #ifndef __EMSCRIPTEN__
 
+int handle_midi_event(void* data, fluid_midi_event_t* event);
+
 static uint8_t sysex_buffer[1024];
 static int sysex_bufptr;
 

--- a/src/midi.h
+++ b/src/midi.h
@@ -11,6 +11,7 @@
 #define MIDI_UART_OSC_RATE_MHZ 16.0f
 #define MIDI_UART_PRIMARY_DIVIDER 16
 
+#define MIDI_TEXT 0x01
 #define NOTE_OFF 0x80
 #define NOTE_ON 0x90
 #define KEY_PRESSURE 0xa0

--- a/src/midi.h
+++ b/src/midi.h
@@ -33,6 +33,7 @@
 #define FS_MIDI_ACTIVE_SENSING 0xfe
 #define FS_MIDI_SYSTEM_RESET 0xff
 
+#define FL_DEFAULT_GAIN 0.2f
 
 void midi_init(void);
 void midi_serial_init(void);

--- a/src/midi.h
+++ b/src/midi.h
@@ -41,3 +41,5 @@ void midi_serial_write(uint8_t reg, uint8_t val);
 void midi_load_sf2(uint8_t* filename);
 void midi_synth_render(int16_t* buf, int len);
 bool midi_serial_irq(void);
+
+extern const char *fs_midi_input_device;

--- a/src/midi.h
+++ b/src/midi.h
@@ -42,4 +42,4 @@ void midi_load_sf2(uint8_t* filename);
 void midi_synth_render(int16_t* buf, int len);
 bool midi_serial_irq(void);
 
-extern bool fs_midi_autoconnect;
+extern bool fs_midi_in_connect;

--- a/src/midi.h
+++ b/src/midi.h
@@ -17,3 +17,4 @@ void midi_serial_step(int clocks);
 uint8_t midi_serial_read(uint8_t reg, bool debugOn);
 void midi_serial_write(uint8_t reg, uint8_t val);
 void midi_load_sf2(uint8_t* filename);
+void midi_synth_render(int16_t* buf, int len);

--- a/src/midi.h
+++ b/src/midi.h
@@ -11,6 +11,28 @@
 #define MIDI_UART_OSC_RATE_MHZ 16.0f
 #define MIDI_UART_PRIMARY_DIVIDER 16
 
+#define NOTE_OFF 0x80
+#define NOTE_ON 0x90
+#define KEY_PRESSURE 0xa0
+#define CONTROL_CHANGE 0xb0
+#define PROGRAM_CHANGE 0xc0
+#define CHANNEL_PRESSURE 0xd0
+#define PITCH_BEND 0xe0
+#define MIDI_SYSEX 0xf0
+#define MIDI_TIME_CODE 0xf1
+#define MIDI_SONG_POSITION 0xf2
+#define MIDI_SONG_SELECT 0xf3
+#define MIDI_TUNE_REQUEST 0xf6
+#define MIDI_EOX 0xf7
+#define MIDI_SYNC 0xf8
+#define MIDI_TICK 0xf9
+#define MIDI_START 0xfa
+#define MIDI_CONTINUE 0xfb
+#define MIDI_STOP 0xfc
+#define MIDI_ACTIVE_SENSING 0xfe
+#define MIDI_SYSTEM_RESET 0xff
+
+
 void midi_init();
 void midi_serial_init();
 void midi_serial_step(int clocks);
@@ -18,3 +40,4 @@ uint8_t midi_serial_read(uint8_t reg, bool debugOn);
 void midi_serial_write(uint8_t reg, uint8_t val);
 void midi_load_sf2(uint8_t* filename);
 void midi_synth_render(int16_t* buf, int len);
+int handle_midi_event(void* data, fluid_midi_event_t* event);

--- a/src/midi.h
+++ b/src/midi.h
@@ -1,0 +1,14 @@
+// Commander X16 Emulator
+// Copyright (c) 2024 MooingLemur
+// All rights reserved. License: 2-clause BSD
+
+#pragma once
+
+#ifndef __EMSCRIPTEN__
+#include <fluidsynth.h>
+#endif
+
+void midi_init();
+uint8_t midi_serial_read(uint8_t reg, bool debugOn);
+void midi_serial_write(uint8_t reg, uint8_t val);
+void midi_load_sf2(uint8_t* filename);

--- a/src/midi.h
+++ b/src/midi.h
@@ -40,4 +40,3 @@ uint8_t midi_serial_read(uint8_t reg, bool debugOn);
 void midi_serial_write(uint8_t reg, uint8_t val);
 void midi_load_sf2(uint8_t* filename);
 void midi_synth_render(int16_t* buf, int len);
-int handle_midi_event(void* data, fluid_midi_event_t* event);

--- a/src/midi.h
+++ b/src/midi.h
@@ -42,3 +42,4 @@ void midi_load_sf2(uint8_t* filename);
 void midi_synth_render(int16_t* buf, int len);
 bool midi_serial_irq(void);
 
+extern bool fs_midi_autoconnect;

--- a/src/midi.h
+++ b/src/midi.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#ifndef __EMSCRIPTEN__
+#ifdef HAS_FLUIDSYNTH
 #include <fluidsynth.h>
 #endif
 

--- a/src/midi.h
+++ b/src/midi.h
@@ -11,31 +11,31 @@
 #define MIDI_UART_OSC_RATE_MHZ 16.0f
 #define MIDI_UART_PRIMARY_DIVIDER 16
 
-#define MIDI_TEXT 0x01
-#define NOTE_OFF 0x80
-#define NOTE_ON 0x90
-#define KEY_PRESSURE 0xa0
-#define CONTROL_CHANGE 0xb0
-#define PROGRAM_CHANGE 0xc0
-#define CHANNEL_PRESSURE 0xd0
-#define PITCH_BEND 0xe0
-#define MIDI_SYSEX 0xf0
-#define MIDI_TIME_CODE 0xf1
-#define MIDI_SONG_POSITION 0xf2
-#define MIDI_SONG_SELECT 0xf3
-#define MIDI_TUNE_REQUEST 0xf6
-#define MIDI_EOX 0xf7
-#define MIDI_SYNC 0xf8
-#define MIDI_TICK 0xf9
-#define MIDI_START 0xfa
-#define MIDI_CONTINUE 0xfb
-#define MIDI_STOP 0xfc
-#define MIDI_ACTIVE_SENSING 0xfe
-#define MIDI_SYSTEM_RESET 0xff
+#define FS_MIDI_TEXT 0x01
+#define FS_NOTE_OFF 0x80
+#define FS_NOTE_ON 0x90
+#define FS_KEY_PRESSURE 0xa0
+#define FS_CONTROL_CHANGE 0xb0
+#define FS_PROGRAM_CHANGE 0xc0
+#define FS_CHANNEL_PRESSURE 0xd0
+#define FS_PITCH_BEND 0xe0
+#define FS_MIDI_SYSEX 0xf0
+#define FS_MIDI_TIME_CODE 0xf1
+#define FS_MIDI_SONG_POSITION 0xf2
+#define FS_MIDI_SONG_SELECT 0xf3
+#define FS_MIDI_TUNE_REQUEST 0xf6
+#define FS_MIDI_EOX 0xf7
+#define FS_MIDI_SYNC 0xf8
+#define FS_MIDI_TICK 0xf9
+#define FS_MIDI_START 0xfa
+#define FS_MIDI_CONTINUE 0xfb
+#define FS_MIDI_STOP 0xfc
+#define FS_MIDI_ACTIVE_SENSING 0xfe
+#define FS_MIDI_SYSTEM_RESET 0xff
 
 
-void midi_init();
-void midi_serial_init();
+void midi_init(void);
+void midi_serial_init(void);
 void midi_serial_step(int clocks);
 uint8_t midi_serial_read(uint8_t reg, bool debugOn);
 void midi_serial_write(uint8_t reg, uint8_t val);

--- a/src/midi.h
+++ b/src/midi.h
@@ -8,7 +8,12 @@
 #include <fluidsynth.h>
 #endif
 
+#define MIDI_UART_OSC_RATE_MHZ 16.0f
+#define MIDI_UART_PRIMARY_DIVIDER 16
+
 void midi_init();
+void midi_serial_init();
+void midi_serial_step(int clocks);
 uint8_t midi_serial_read(uint8_t reg, bool debugOn);
 void midi_serial_write(uint8_t reg, uint8_t val);
 void midi_load_sf2(uint8_t* filename);

--- a/src/midi.h
+++ b/src/midi.h
@@ -40,3 +40,4 @@ uint8_t midi_serial_read(uint8_t reg, bool debugOn);
 void midi_serial_write(uint8_t reg, uint8_t val);
 void midi_load_sf2(uint8_t* filename);
 void midi_synth_render(int16_t* buf, int len);
+bool midi_serial_irq(void);

--- a/src/midi.h
+++ b/src/midi.h
@@ -42,4 +42,3 @@ void midi_load_sf2(uint8_t* filename);
 void midi_synth_render(int16_t* buf, int len);
 bool midi_serial_irq(void);
 
-extern const char *fs_midi_input_device;


### PR DESCRIPTION
This PR adds serial MIDI support

* The "wavetable" support is emulated by FluidSynth with a loadable SoundFont.  I have not found an unencumbered General MIDI soundfont that we could distribute legally beyond a reasonable doubt, so it's up to users to obtain and load their own.
* FluidSynth can also hook up the default system MIDI IN, and x16emu can tie it to the serial input of the first emulated UART.
* FluidSynth's internal MIDI synth audio is mixed into the rest of x16emu's audio, alongside VERA and FM.
* Unfortunately, FluidSynth does not present the operating system's MIDI OUT, so the internal synth is currently tied to both UARTs' outputs.  With additional work we could use the native MIDI libraries on each operating system to plumb the first UART to a hardware MIDI out in the future.
* As FluidSynth runs in its own threads, and MIDI input is event driven with a threaded callback into x16emu code, x16emu needs to handle the buffers in a thread-safe way, so this is the beginning of thread code in x16emu.
* fluidsynth is now a build dependency for x16emu but not a strict runtime dependency, as we are using dynamic library loading.