### PR TITLE
Add ability to choose CPU- type and speed in web emulator

### DIFF
--- a/webassembly/main.js
+++ b/webassembly/main.js
@@ -78,9 +78,8 @@ var emuArguments = ['-keymap', lang, '-rtc'];
 if (ram_val) {
     emuArguments.push('-ram', ram_val);
 }
-
 if (dbg_val != null) {
-    emuArguments.push('debug', dbg_val);
+    emuArguments.push('-debug', dbg_val);
 }
 
 if (manifest_link) {

--- a/webassembly/main.js
+++ b/webassembly/main.js
@@ -71,15 +71,20 @@ if (layouts.includes(lang)) {
 var url = new URL(window.location.href);
 var manifest_link = url.searchParams.get("manifest");
 var ram_val = url.searchParams.get("ram");
-var dbg_val = url.searchParams.get("debug");
+var cpu_val = url.searchParams.get("cpu");
+var mhz_val = url.searchParams.get("mhz");
 
 var emuArguments = ['-keymap', lang, '-rtc'];
 
 if (ram_val) {
     emuArguments.push('-ram', ram_val);
 }
-if (dbg_val != null) {
-    emuArguments.push('-debug', dbg_val);
+if (cpu_val) {
+    if (cpu_val == 'c816')
+        emuArguments.push('-c816');
+}
+if (mhz_val) {
+    emuArguments.push('-mhz', mhz_val);
 }
 
 if (manifest_link) {

--- a/webassembly/main.js
+++ b/webassembly/main.js
@@ -78,6 +78,7 @@ var emuArguments = ['-keymap', lang, '-rtc'];
 if (ram_val) {
     emuArguments.push('-ram', ram_val);
 }
+
 if (dbg_val != null) {
     emuArguments.push('debug', dbg_val);
 }

--- a/webassembly/main.js
+++ b/webassembly/main.js
@@ -71,11 +71,15 @@ if (layouts.includes(lang)) {
 var url = new URL(window.location.href);
 var manifest_link = url.searchParams.get("manifest");
 var ram_val = url.searchParams.get("ram");
+var dbg_val = url.searchParams.get("debug");
 
 var emuArguments = ['-keymap', lang, '-rtc'];
 
 if (ram_val) {
     emuArguments.push('-ram', ram_val);
+}
+if (dbg_val != null) {
+    emuArguments.push('debug', dbg_val);
 }
 
 if (manifest_link) {


### PR DESCRIPTION
Added CPU and MHz options to the webemulator to allow choosing CPU type and CPU speed.

To choose the 65C816 cpu following can be used:
https://cx16forum.com/webemu/x16emu.html?manifest=/forum/download/file.php?id=1218&cpu=c816

To choose speed, the following can be used:
https://cx16forum.com/webemu/x16emu.html?manifest=/forum/download/file.php?id=1218&mhz=4

This came about because someone on the forum (x16os) complained that it is not possible to choose the 65C816 cpu in try-it-now