### PR TITLE
Added multiple options to webemulator.

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,63 @@ The following keys can be used for controlling games:
 |Cursor Right  | RIGHT           |
 
 
+Options for the WebEmulator
+--------
+
+The following options are available for the WebEmulator. With the exception of manifest, they all work exactly the same as in the normal emulator.
+* `manifest`
+* `ram`
+* `cpu`
+* `mhz`
+* `keymap`
+* `longpwron`
+* `widescreen`
+* `capture`
+
+#### The Address Line
+`manifest` tells the emulator what should be loaded as a startup program. If the file is a .bas or .prg, the emulator will load it and try to execute it. If the file is a .zip, the WebEmulator will get access to all the files inside that zip-file. When using a zip-file you may add a manifest file to provide additional information - See section below for more information on `manifest.json`
+
+On the Commander X16 forums, a link to the webemulator could look something like this:
+https://cx16forum.org/webemu/x16emu.html?manifest=/forum/download/file.php?id=1218&ram=2048&cpu=c816&mhz=10&keymap=da&widescreen&capture&longpwron  
+This will load the forum file with id 1218 into the emulator.  
+Give the emulator 2MB of RAM  
+Set the CPU type to 65C816  
+Set the CPU speed at 10 MHz  
+Set the keyboard layout to Danish  
+Show the emulator in widescreen mode  
+Capture the mouse and keyboard input   
+Start the emulator in RAM diagnostics mode  
+The last 3 options do not have any values, it is enough to have them on the address line to enable the feature.
+
+#### The manifest.json File
+If an application requires more than a single file to function, for example graphics or audio assets, it is necessary to package the needed files in a zip file. If there are more than one start file (BAS or PRG) the `manifest.json` file can be used to specify the default start file with `start_prg` or `start_bas` otherwise the WebEmulator will start the .prg or .bas it finds in the zip file.  
+
+Here is an example of the optional `manifest.json` file  
+	
+	{
+		"manifest_version": "1.0.0",
+		"name": "My Program",
+		"author": "John Smith",
+		"app_version": "1.0.0",
+		"license": "GPL 3",
+		"ram": "2048",
+		"cpu": "c816",
+		"mhz": "10",
+		"keymap": "da",
+		"widescreen": true,
+		"capture": true,
+		"longpwron": false,
+		"start_prg": "MYPROG.PRG",
+		"resources": [
+			"MYPROG.PRG",
+			"FILE1.BIN",
+			"FILE2.BIN"
+		]
+	}
+
+If the resources section is present, only files specified will be made available to the WebEmulator.  
+Options set in `manifest.json` will override options on the address line.
+
 Functions while running
 -----------------------
 

--- a/README.md
+++ b/README.md
@@ -199,21 +199,21 @@ The following options are available for the WebEmulator. With the exception of m
 * `longpwron`
 * `widescreen`
 * `capture`
+* `midlineeffects`
 
 #### The Address Line
 `manifest` tells the emulator what should be loaded as a startup program. If the file is a .bas or .prg, the emulator will load it and try to execute it. If the file is a .zip, the WebEmulator will get access to all the files inside that zip-file. When using a zip-file you may add a manifest file to provide additional information - See section below for more information on `manifest.json`
 
 On the Commander X16 forums, a link to the webemulator could look something like this:
-https://cx16forum.org/webemu/x16emu.html?manifest=/forum/download/file.php?id=1218&ram=2048&cpu=c816&mhz=10&keymap=da&widescreen&capture&longpwron  
+https://cx16forum.org/webemu/x16emu.html?manifest=/forum/download/file.php?id=1218&ram=2048&cpu=c816&mhz=10&keymap=da&widescreen&capture  
 This will load the forum file with id 1218 into the emulator.  
 Give the emulator 2MB of RAM  
 Set the CPU type to 65C816  
 Set the CPU speed at 10 MHz  
 Set the keyboard layout to Danish  
 Show the emulator in widescreen mode  
-Capture the mouse and keyboard input   
-Start the emulator in RAM diagnostics mode  
-The last 3 options do not have any values, it is enough to have them on the address line to enable the feature.
+Capture the mouse and keyboard input 
+The options `longpwron`, `widescreen`, `capture` & `midlineeffects` do not have any values, it is enough to have them on the address line to enable the feature.
 
 #### The manifest.json File
 If an application requires more than a single file to function, for example graphics or audio assets, it is necessary to package the needed files in a zip file. If there are more than one start file (BAS or PRG) the `manifest.json` file can be used to specify the default start file with `start_prg` or `start_bas` otherwise the WebEmulator will start the .prg or .bas it finds in the zip file.  
@@ -233,6 +233,7 @@ Here is an example of the optional `manifest.json` file
 		"widescreen": true,
 		"capture": true,
 		"longpwron": false,
+		"midlineeffects": false,
 		"start_prg": "MYPROG.PRG",
 		"resources": [
 			"MYPROG.PRG",

--- a/webassembly/main.js
+++ b/webassembly/main.js
@@ -73,6 +73,10 @@ var manifest_link = url.searchParams.get("manifest");
 var ram_val = url.searchParams.get("ram");
 var cpu_val = url.searchParams.get("cpu");
 var mhz_val = url.searchParams.get("mhz");
+var lang_val = url.searchParams.get("keymap");
+var diag = url.searchParams.get("longpwron");
+var wide = url.searchParams.get("widescreen");
+var capture = url.searchParams.get("capture");
 
 var emuArguments = ['-keymap', lang, '-rtc'];
 
@@ -80,11 +84,24 @@ if (ram_val) {
     emuArguments.push('-ram', ram_val);
 }
 if (cpu_val) {
-    if (cpu_val == 'c816')
+    if (cpu_val == 'c816') {
         emuArguments.push('-c816');
+    }
 }
 if (mhz_val) {
     emuArguments.push('-mhz', mhz_val);
+}
+if (lang_val) {
+    emuArguments.push('-keymap', lang_val);
+}
+if (diag != null) {
+    emuArguments.push('-longpwron');
+}
+if (wide != null) {
+    emuArguments.push('-widescreen');
+}
+if (capture != null) {
+    emuArguments.push('-capture');
 }
 
 if (manifest_link) {
@@ -309,6 +326,36 @@ function extractManifestFromBuffer(zip) {
                 let manifestObject = JSON.parse(manifestString);
                 console.log("Parsed manifest from zip:")
                 console.log(manifestObject);
+
+		if (manifestObject.ram) {
+			console.log('Found RAM amount: '+manifestObject.ram);
+			emuArguments.push('-ram', manifestObject.ram);
+		}
+		if (manifestObject.cpu) {
+			console.log('Found CPU type: '+manifestObject.cpu);
+			if (manifestObject.cpu == 'c816')
+				emuArguments.push('-c816');
+		}
+		if (manifestObject.mhz) {
+			console.log('Found mhz variable: '+manifestObject.mhz);
+			emuArguments.push('-mhz', manifestObject.mhz);
+		}
+		if (manifestObject.keymap) {
+			console.log('Found keymap variable: '+manifestObject.keymap);
+			emuArguments.push('-keymap', manifestObject.keymap);
+		}
+		if (manifestObject.longpwron) {
+			console.log('Found longpwron variable');
+			emuArguments.push('-longpwron');
+		}
+		if (manifestObject.widescreen) {
+			console.log('Found widescreen variable');
+			emuArguments.push('-widescreen');
+		}
+		if (manifestObject.capture) {
+			console.log('Found capture variable');
+			emuArguments.push('-capture');
+		}
 
                 const promises = [];
                 if (manifestObject.resources) {

--- a/webassembly/main.js
+++ b/webassembly/main.js
@@ -77,6 +77,7 @@ var lang_val = url.searchParams.get("keymap");
 var diag = url.searchParams.get("longpwron");
 var wide = url.searchParams.get("widescreen");
 var capture = url.searchParams.get("capture");
+var midline = url.searchParams.get("midlineeffects");
 
 var emuArguments = ['-keymap', lang, '-rtc'];
 
@@ -102,6 +103,9 @@ if (wide != null) {
 }
 if (capture != null) {
     emuArguments.push('-capture');
+}
+if (midline != null) {
+    emuArguments.push('-midline-effects');
 }
 
 if (manifest_link) {
@@ -355,6 +359,10 @@ function extractManifestFromBuffer(zip) {
 		if (manifestObject.capture) {
 			console.log('Found capture variable');
 			emuArguments.push('-capture');
+		}
+		if (manifestObject.midlineeffects) {
+			console.log('Found midlineeffects variable');
+			emuArguments.push('-midline-effects');
 		}
 
                 const promises = [];


### PR DESCRIPTION
Now the webemulator is able to handle the following options:
* ram = amount of memory in steps of 8K (8-2048)
* cpu = c816 or c02
* mhz = speed in MHz, minimum 1
* keymap = same list of keymaps supported as normal emualtor
* longpwron = Boot emulator into RAM diagnostics
* widescreen = enable widescreen if true
* capture = capture keyboard and mouse if true All of the above options are available on the address/url or in the manifest file. On the address line longpwron, widescreen & capture do not need values to be enabled. In the manifest file, they must be set to true.
Options in manifest file take precedens over options on address line.

On the address line the options would look something like this:
?manifest=myprog.prg&ram=2048&cpu=c816&mhz=10&keymap=da&widescreen&capture&longpwron

The options in the manifest file would look like this:
"ram": "2048",
"cpu": "c816",
"mhz": "10",
"keymap": "da",
"widescreen": true,
"capture": true,
"longpwron": false,
