### PR TITLE
Enable actively selecting 65C02 as CPU type in WebEmulator

### DIFF
--- a/webassembly/main.js
+++ b/webassembly/main.js
@@ -87,6 +87,8 @@ if (ram_val) {
 if (cpu_val) {
     if (cpu_val == 'c816') {
         emuArguments.push('-c816');
+    } elseif (cpu_val == 'c02') {
+	emuArguments.push('-c02');
     }
 }
 if (mhz_val) {

--- a/webassembly/main.js
+++ b/webassembly/main.js
@@ -339,8 +339,11 @@ function extractManifestFromBuffer(zip) {
 		}
 		if (manifestObject.cpu) {
 			console.log('Found CPU type: '+manifestObject.cpu);
-			if (manifestObject.cpu == 'c816')
+			if (manifestObject.cpu == 'c816') {
 				emuArguments.push('-c816');
+			} elseif (manifestObject.cpu == 'c02') {
+				emuArguments.push('c02');
+			}
 		}
 		if (manifestObject.mhz) {
 			console.log('Found mhz variable: '+manifestObject.mhz);


### PR DESCRIPTION
As the 65C816 may become the default CPU type in the future, the cpu option now checks for both
c816 and c02 to ensure that it can be selected correctly and not just rely on the default CPU.