### PR TITLE
fix behavior of mvn and mvp when C register = $FFFF

### DIFF
--- a/src/cpu/instructions.h
+++ b/src/cpu/instructions.h
@@ -829,27 +829,23 @@ static void tsc() {
 }
 
 static void mvn() {
-    if (regs.c != 0xFFFF) {
-        if (index_16bit()) {
-            write6502(regs.y++, read6502(regs.x++));
-        } else {
-            write6502(regs.yl++, read6502(regs.xl++));
-        }
-
-        regs.c--;
+    if (index_16bit()) {
+        write6502(regs.y++, read6502(regs.x++));
+    } else {
+        write6502(regs.yl++, read6502(regs.xl++));
+    }
+    if (--regs.c != 0xFFFF) {
         regs.pc -= 3;
     }
 }
 
 static void mvp() {
-    if (regs.c != 0xFFFF) {
-        if (index_16bit()) {
-            write6502(regs.y--, read6502(regs.x--));
-        } else {
-            write6502(regs.yl--, read6502(regs.xl--));
-        }
-
-        regs.c--;
+    if (index_16bit()) {
+        write6502(regs.y--, read6502(regs.x--));
+    } else {
+        write6502(regs.yl--, read6502(regs.xl--));
+    }
+    if (--regs.c != 0xFFFF) {
         regs.pc -= 3;
     }
 }


### PR DESCRIPTION
The current version of the emulator copies zero bytes when the `mvn` and `mvp` instructions are executed. The correct behavior is to copy 65536 bytes. 

This caused situations where code can run successfully on the emulator, but causes a crash on hardware.