### PR TITLE
[BUILD] CI/CD update for macos

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -371,8 +371,8 @@ jobs:
           path: emu_binaries/*
   build-macos-x86_64:
     needs: [README]
-    # this is currently macos-12, Monterey
-    runs-on: macos-12
+    # this is currently macos-13, Ventura
+    runs-on: macos-13
     steps:
       - uses: actions/checkout@v4
       - name: Install Dependencies


### PR DESCRIPTION
GitHub has removed MacOS 12 runners completely.