### PR TITLE
Fix missing dash when explicitly selecting c02 CPU in webemulator

### DIFF
--- a/webassembly/main.js
+++ b/webassembly/main.js
@@ -342,7 +342,7 @@ function extractManifestFromBuffer(zip) {
 			if (manifestObject.cpu == 'c816') {
 				emuArguments.push('-c816');
 			} elseif (manifestObject.cpu == 'c02') {
-				emuArguments.push('c02');
+				emuArguments.push('-c02');
 			}
 		}
 		if (manifestObject.mhz) {


### PR DESCRIPTION
When specifically selecting the 65c02 CPU in a manifest file, the argument pushed to the emulator was without a dash