### PR TITLE
MVN/MVP: Fix opcode bank bytes arguments being in the wrong order

### DIFF
--- a/src/cpu/modes.h
+++ b/src/cpu/modes.h
@@ -192,8 +192,8 @@ static void sridy() { // (indirect,S),Y
 }
 
 static void bmv() { // block move
-    uint8_t src = read6502(regs.pc++);
-    ea = (src << 8) | read6502(regs.pc++);
+    uint8_t dest = read6502(regs.pc++);
+    ea = (read6502(regs.pc++) << 8) | dest;
 }
 
 static void absl() { // absolute long

--- a/src/disasm.c
+++ b/src/disasm.c
@@ -308,7 +308,7 @@ int disasm(uint16_t pc, uint8_t *RAM, char *line, unsigned int max_line, int16_t
 	}
 
 	if (isBlockMove) {
-		snprintf(line, max_line, mnemonic, debug_read6502(pc + 1, bank), debug_read6502(pc + 2, bank));
+		snprintf(line, max_line, mnemonic, debug_read6502(pc + 2, bank), debug_read6502(pc + 1, bank));
 		length = 3;
 		if (regs.c != 0xFFFF) *eff_addr = regs.y; // We can have only one effective address, so we're choosing the destination
 	}


### PR DESCRIPTION
MVN/MVP are assembled as `mvn source,dest`, however the bytes are ordered in the opposite order - `mvn #$12, #$34` assembles to `$54 $34 $12`.