### PR TITLE
HostFS: Improve general performance of MACPTR, add XMACPTR and XMCIOUT implementations.

### DIFF
--- a/src/ieee.c
+++ b/src/ieee.c
@@ -2090,9 +2090,9 @@ XMACPTR(uint8_t stream_mode) // stream_mode is only for passing into MACPTR fall
 {
 	if (talking) {
 		int ret = 0;
-		int count = read6502(6, 0) | (read6502(7, 0) << 8);
-		uint16_t destaddr = read6502(2, 0) | (read6502(3, 0) << 8);
-		uint8_t destbnk = read6502(4, 0);
+		int count = read6502(X16_REG_R2L, 0) | (read6502(X16_REG_R2H, 0) << 8);
+		uint16_t destaddr = read6502(X16_REG_R0L, 0) | (read6502(X16_REG_R0H, 0) << 8);
+		uint8_t destbnk = read6502(X16_REG_R1L, 0);
 
 		if (count == 0) {
 			count = 65536;
@@ -2105,8 +2105,8 @@ XMACPTR(uint8_t stream_mode) // stream_mode is only for passing into MACPTR fall
 			if (s < 0) {
 				return s;
 			}
-			write6502(6, 0, cnt & 0xff);
-			write6502(7, 0, cnt >> 8);
+			write6502(X16_REG_R2L, 0, cnt & 0xff);
+			write6502(X16_REG_R2H, 0, cnt >> 8);
 			return s;
 		}
 
@@ -2147,8 +2147,8 @@ XMACPTR(uint8_t stream_mode) // stream_mode is only for passing into MACPTR fall
 		} else {
 			ret = -3; // unsupported
 		}
-		write6502(6, 0, i & 0xff);
-		write6502(7, 0, i >> 8);
+		write6502(X16_REG_R2L, 0, i & 0xff);
+		write6502(X16_REG_R2H, 0, i >> 8);
 		return ret;
 	} else {
 		return -2; // not us, do not handle
@@ -2160,9 +2160,9 @@ XMCIOUT(uint8_t stream_mode) // stream_mode is only for passing into MCIOUT fall
 {
 	if (listening) {
 		int ret = 0;
-		int count = read6502(6, 0) | (read6502(7, 0) << 8);
-		uint16_t srcaddr = read6502(2, 0) | (read6502(3, 0) << 8);
-		uint8_t srcbnk = read6502(4, 0);
+		int count = read6502(X16_REG_R2L, 0) | (read6502(X16_REG_R2H, 0) << 8);
+		uint16_t srcaddr = read6502(X16_REG_R0L, 0) | (read6502(X16_REG_R0H, 0) << 8);
+		uint8_t srcbnk = read6502(X16_REG_R1L, 0);
 
 		if (count == 0) {
 			count = 65536;
@@ -2175,8 +2175,8 @@ XMCIOUT(uint8_t stream_mode) // stream_mode is only for passing into MCIOUT fall
 			if (s < 0) {
 				return s;
 			}
-			write6502(6, 0, cnt & 0xff);
-			write6502(7, 0, cnt >> 8);
+			write6502(X16_REG_R2L, 0, cnt & 0xff);
+			write6502(X16_REG_R2H, 0, cnt >> 8);
 			return s;
 		}
 
@@ -2202,8 +2202,8 @@ XMCIOUT(uint8_t stream_mode) // stream_mode is only for passing into MCIOUT fall
 			ret = -3; // unsupported
 		}
 
-		write6502(6, 0, i & 0xff);
-		write6502(7, 0, i >> 8);
+		write6502(X16_REG_R2L, 0, i & 0xff);
+		write6502(X16_REG_R2H, 0, i >> 8);
 		return ret;
 	} else {
 		return -2; // not us, do not handle

--- a/src/ieee.h
+++ b/src/ieee.h
@@ -13,3 +13,5 @@ int LISTEN(uint8_t a);
 int TALK(uint8_t a);
 int MACPTR(uint16_t addr, uint16_t *count, uint8_t stream_mode);
 int MCIOUT(uint16_t addr, uint16_t *count, uint8_t stream_mode);
+int XMACPTR(uint8_t stream_mode);
+int XMCIOUT(uint8_t stream_mode);

--- a/src/main.c
+++ b/src/main.c
@@ -1412,8 +1412,8 @@ handle_ieee_intercept()
 	int s = -1;
 	switch(regs.pc) {
 		case 0xFEA8: { // EXTAPI16
-			if (!regs.is65c816) {
-				handled = false; // punt to kernal's 65C816 check which should return c=1.
+			if (!regs.is65c816 || (regs.status & 0x20)) { // don't handle if not '816 or if m=1
+				handled = false; // punt to kernal's 65C816 check and will break if m=1
 				break;
 			}
 			switch(regs.c) {
@@ -1423,8 +1423,9 @@ handle_ieee_intercept()
 						handled = false;
 					} else if (s == -3) {
 						regs.status |= 1; // SEC (unsupported, or in this case, no open context)
+						regs.status &= ~0x30; // REP #$30
 					} else {
-						regs.status &= 0xfe; // CLC -> supported
+						regs.status &= ~0x31; // REP #$30 and CLC -> supported
 					}
 					break;
 				}
@@ -1434,8 +1435,9 @@ handle_ieee_intercept()
 						handled = false;
 					} else if (s == -3) {
 						regs.status |= 1; // SEC (unsupported, or in this case, no open context)
+						regs.status &= ~0x30; // REP #$30
 					} else {
-						regs.status &= 0xfe; // CLC -> supported
+						regs.status &= ~0x31; // REP #$30 and CLC -> supported
 					}
 					break;
 				}

--- a/src/memory.h
+++ b/src/memory.h
@@ -13,7 +13,41 @@
 #define BANK_SIZE 65536
 
 #define USE_CURRENT_X16_BANK (-1)
-#define debug_read6502(a, b, x) real_read6502(a, b, true, x)
+#define debug_read6502(a, b, x) real_read6502((a), (b), true, (x))
+
+// X16 r0-r15
+#define X16_REG_R0L (direct_page_add(2))
+#define X16_REG_R0H (direct_page_add(3))
+#define X16_REG_R1L (direct_page_add(4))
+#define X16_REG_R1H (direct_page_add(5))
+#define X16_REG_R2L (direct_page_add(6))
+#define X16_REG_R2H (direct_page_add(7))
+#define X16_REG_R3L (direct_page_add(8))
+#define X16_REG_R3H (direct_page_add(9))
+#define X16_REG_R4L (direct_page_add(10))
+#define X16_REG_R4H (direct_page_add(11))
+#define X16_REG_R5L (direct_page_add(12))
+#define X16_REG_R5H (direct_page_add(13))
+#define X16_REG_R6L (direct_page_add(14))
+#define X16_REG_R6H (direct_page_add(15))
+#define X16_REG_R7L (direct_page_add(16))
+#define X16_REG_R7H (direct_page_add(17))
+#define X16_REG_R8L (direct_page_add(18))
+#define X16_REG_R8H (direct_page_add(19))
+#define X16_REG_R9L (direct_page_add(20))
+#define X16_REG_R9H (direct_page_add(21))
+#define X16_REG_R10L (direct_page_add(22))
+#define X16_REG_R10H (direct_page_add(23))
+#define X16_REG_R11L (direct_page_add(24))
+#define X16_REG_R11H (direct_page_add(25))
+#define X16_REG_R12L (direct_page_add(26))
+#define X16_REG_R12H (direct_page_add(27))
+#define X16_REG_R13L (direct_page_add(28))
+#define X16_REG_R13H (direct_page_add(29))
+#define X16_REG_R14L (direct_page_add(30))
+#define X16_REG_R14H (direct_page_add(31))
+#define X16_REG_R15L (direct_page_add(32))
+#define X16_REG_R15H (direct_page_add(33))
 
 uint8_t read6502(uint16_t address, uint8_t bank);
 uint8_t real_read6502(uint16_t address, uint8_t bank, bool debugOn, int16_t x16Bank);


### PR DESCRIPTION
Turns out seeking is very expensive, but we need to do it to find EOF ahead of time for reads.

When MACPTR delegates to ACPTR, we do the seeks for every byte read, which adds significant overhead.

Rather than delegating block reads to ACPTR, we bring the loop inside MACPTR and XMACPTR so we can find EOF with only one set of seeks per read block.