### PR TITLE
Merge master to gen2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -198,7 +198,7 @@ jobs:
           path: emu_binaries/*
   build-linux-x86_64:
     needs: [README]  
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -251,7 +251,7 @@ jobs:
           path: emu_binaries/*
   build-linux-aarch64:
     needs: [README]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -311,7 +311,7 @@ jobs:
           path: emu_binaries/*
   build-linux-armhf:
     needs: [README]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5


### PR DESCRIPTION
There were some null conflicts that resulted from my previous botched rebase on `gen2` after both @Fulgen301 and I started working on it.  This should make it happy and allow a merge from gen2 back to master later.

This also ports the latest CI changes from master to gen2.