### PR TITLE
Exclude threading in wasm build.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ endif
 
 CFLAGS=-std=c11 -O3 -Wall -Werror -g $(shell $(SDL2CONFIG) --cflags) -Isrc/extern/include
 CXXFLAGS=-std=c++17 -O3 -Wall -Werror -Isrc/extern/ymfm/src
-LDFLAGS=$(shell $(SDL2CONFIG) --libs) -lm -lz -pthread
+LDFLAGS=$(shell $(SDL2CONFIG) --libs) -lm -lz
 
 ifdef ADDL_INCLUDE
 	CFLAGS+=-I$(ADDL_INCLUDE)
@@ -77,6 +77,8 @@ ifdef EMSCRIPTEN
 	CFLAGS+=-s USE_ZLIB=1
 	X16_OUTPUT=x16emu.html
 	MAKECART_OUTPUT=makecart.html
+else
+	LDFLAGS+=-pthread
 endif
 
 ifeq ($(FLUIDSYNTH),1)

--- a/src/main.c
+++ b/src/main.c
@@ -1261,7 +1261,11 @@ main(int argc, char **argv)
 #ifdef SDL_HINT_SCREENSAVER_INHIBIT_ACTIVITY_NAME
 		SDL_SetHint(SDL_HINT_SCREENSAVER_INHIBIT_ACTIVITY_NAME, "Emulating modern retro awesomeness");
 #endif
-		SDL_Init(SDL_INIT_VIDEO | SDL_INIT_EVENTS | SDL_INIT_GAMECONTROLLER | SDL_INIT_AUDIO | SDL_INIT_TIMER);
+		int e = SDL_Init(SDL_INIT_VIDEO | SDL_INIT_EVENTS | SDL_INIT_GAMECONTROLLER | SDL_INIT_AUDIO | SDL_INIT_TIMER);
+		if (e < 0) {
+			fprintf(stderr, "SDL_Init failed: %s\n", SDL_GetError());
+			exit(-1);
+		}
 		audio_init(audio_dev_name, audio_buffers);
 		video_init(window_scale, screen_x_scale, scale_quality, fullscreen, window_opacity);
 	}


### PR DESCRIPTION
When threading is enabled for a WebAssembly app, this is achieved via the [SharedArrayBuffer](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer) API.

This places [additional constraints](https://web.dev/articles/coop-coep) on the HTTP headers for the web server that serves the resources for the app in order for the app to use threads.  If threads are available at SDL_Init(), the SDL subsystem will attempt to create threads for itself, and if the HTTP headers are not set correctly, SDL_Init() fails.

However, we do not need threading support in the wasm build at all, as this support is only necessary if we build in fluidsynth, which is not currently part of the x16-emulator wasm build.

Closes #331 