### PR TITLE
Writing to 65c22 IFR (reg 13) clears any flag specified in the written byte

### DIFF
--- a/src/via.c
+++ b/src/via.c
@@ -98,7 +98,6 @@ via_read(via_t *via, uint8_t reg, bool debug)
 static void
 via_write(via_t *via, uint8_t reg, uint8_t value)
 {
-	uint8_t pcr;
 	switch (reg) {
 		case 0: // ORB
 			via_clear_prb_irqs(via);

--- a/src/via.c
+++ b/src/via.c
@@ -132,7 +132,7 @@ via_write(via_t *via, uint8_t reg, uint8_t value)
 			via->registers[10] = value;
 			break;
 		case 13: // IFR
-			via->registers[13] &= ~value;
+			via->registers[13] &= ~(value & 0x7f);
 			break;
 		case 14: // IER
 			if (value & 0x80) {

--- a/src/via.c
+++ b/src/via.c
@@ -132,13 +132,7 @@ via_write(via_t *via, uint8_t reg, uint8_t value)
 			via->registers[10] = value;
 			break;
 		case 13: // IFR
-			pcr = via->registers[12];
-			if ((value & 0x01) && ((pcr & 0b00001010) == 0b00000010)) {
-				via->registers[13] &= ~0x01;
-			}
-			if ((value & 0x08) && ((pcr & 0b10100000) == 0b00100000)) {
-				via->registers[13] &= ~0x08;
-			}
+			via->registers[13] &= ~value;
 			break;
 		case 14: // IER
 			if (value & 0x80) {


### PR DESCRIPTION
This matches the behavior of the hardware. Previous implementation only cleared CA2 or CB2 flags, and then only if they were configured as independent interrupts.