### PR TITLE
Debugger: set breakpoint fixes, disasm bank fixes, breakpoint render fixes

### DIFF
--- a/src/debugger.c
+++ b/src/debugger.c
@@ -530,12 +530,12 @@ static void DEBUGExecCmd() {
 
 		case CMD_DISASM:
 			if (sscanf(line, "%x:%x", &bnumber, &number) == 2) {
-				currentPCX16Bank = (number >= 0xA000 && number < 0x10000) ? bnumber & 0xFF : -1;
+				currentPCX16Bank = (number >= 0xA000 && number <= 0xFFFF) ? bnumber & 0xFF : -1;
 			} else {
 				sscanf(line, "%x", &number);
 				if (!is_gen2) {
 					currentPCX16Bank = (number & 0xFFFF) >= 0xA000 ? (number >> 16) & 0xFF : -1;
-				} else if (number < 0xA000) {
+				} else if (number < 0xA000 || number >= 0x010000) {
 					currentPCX16Bank = -1;
 				}
 			}
@@ -901,9 +901,10 @@ static int DEBUGRenderRegisters(void) {
 
 	if (breakPoint.pc < 0) {
 		DEBUGString(dbgRenderer, DBG_DATX, yc++, "----", col_data);
-	} else if (breakPoint.x16Bank < 0 || breakPoint.bank > 0) {
+	} else if (breakPoint.x16Bank < 0) {
 		if (is_gen2) {
-			DEBUGNumber(DBG_DATX, yc++, (uint16_t)breakPoint.pc | (breakPoint.bank << 16), 6, col_data);
+			DEBUGNumber(DBG_DATX, yc, breakPoint.bank, 2, col_data);
+			DEBUGNumber(DBG_DATX+3, yc++, breakPoint.pc, 4, col_data);
 		} else {
 			DEBUGNumber(DBG_DATX, yc++, (uint16_t)breakPoint.pc, 4, col_data);
 		}

--- a/src/debugger.c
+++ b/src/debugger.c
@@ -536,8 +536,8 @@ static void DEBUGExecCmd() {
 			} else if (sscanf(line, "%x", &number) == 1) {
 				if (!is_gen2) {
 					currentPCX16Bank = (number & 0xFFFF) >= 0xA000 ? (number >> 16) & 0xFF : -1;
-				} else if (number < 0xA000 || number >= 0x010000) {
-					currentPCX16Bank = -1;
+				} else if (number < 0x00A000 || number >= 0x010000) { // treat input as 24-bit (K+PC)
+					currentPCX16Bank = -1; // if outside of the X16 banked range, set to undef (-1)
 				}
 			} else {
 				break;

--- a/src/debugger.c
+++ b/src/debugger.c
@@ -318,9 +318,16 @@ static void DEBUGHandleKeyEvent(SDL_Keycode key, int isShift) {
 			break;
 
 		case DBGKEY_SETBRK:                             // F9 Set breakpoint to displayed.
-			breakPoint.pc = currentPC;
-			breakPoint.bank = currentPCBank;
-			breakPoint.x16Bank = currentPCX16Bank;
+			if (breakPoint.pc == currentPC && breakPoint.bank == currentPCBank && breakPoint.x16Bank == currentPCX16Bank) {
+				// Clear (unset) breakpoint by pressing DBGKEY_SETBRK twice
+				breakPoint.pc = -1;
+				breakPoint.bank = 0;
+				breakPoint.x16Bank = -1;
+			} else {
+				breakPoint.pc = currentPC;
+				breakPoint.bank = currentPCBank;
+				breakPoint.x16Bank = currentPCX16Bank;
+			}
 			break;
 
 		case DBGKEY_HOME:                               // F1 sets the display PC to the actual one.

--- a/src/debugger.c
+++ b/src/debugger.c
@@ -485,10 +485,11 @@ static void DEBUGExecCmd() {
 			break;
 
 		case CMD_DUMP_VERA:
-			sscanf(line, "%x", &number);
-			addr = number & 0x1FFFF;
-			currentData = addr;
-			dumpmode    = DDUMP_VERA;
+			if (sscanf(line, "%x", &number) == 1) {
+				addr = number & 0x1FFFF;
+				currentData = addr;
+				dumpmode    = DDUMP_VERA;
+			}
 			break;
 
 		case CMD_FILL_MEMORY:
@@ -551,18 +552,21 @@ static void DEBUGExecCmd() {
 			break;
 
 		case CMD_SET_BANK:
-			sscanf(line, "%s %d", reg, &number);
-
-			if(!strcmp(reg, "rom")) {
-				memory_set_rom_bank(number & 0x00FF);
+			if (sscanf(line, "%s %d", reg, &number) != 2) {
+				break;
 			}
-			if(!strcmp(reg, "ram")) {
+
+			if (!strcmp(reg, "rom")) {
+				memory_set_rom_bank(number & 0x00FF);
+			} else if (!strcmp(reg, "ram")) {
 				memory_set_ram_bank(number & 0x00FF);
 			}
 			break;
 
 		case CMD_SET_REGISTER:
-			sscanf(line, "%s %x", reg, &number);
+			if (sscanf(line, "%s %x", reg, &number) != 2) {
+				break;
+			}
 
 			if(!strcmp(reg, "pc")) {
 				regs.pc= number & 0xFFFF;

--- a/src/debugger.c
+++ b/src/debugger.c
@@ -473,9 +473,12 @@ static void DEBUGExecCmd() {
 			if (sscanf(line, "%x:%x", &bnumber, &number) == 2) {
 				currentX16Bank = bnumber & 0xFF;
 			} else {
-				sscanf(line, "%x", &number);
-				if (!is_gen2) {
-					currentX16Bank = (number >> 16) & 0xFF;
+				if (sscanf(line, "%x", &number) == 1) {
+					if (!is_gen2) {
+						currentX16Bank = (number >> 16) & 0xFF;
+					}
+				} else {
+					break;
 				}
 			}
 			addr = number & (is_gen2 ? 0xFFFFFF : 0xFFFF);
@@ -532,11 +535,14 @@ static void DEBUGExecCmd() {
 			if (sscanf(line, "%x:%x", &bnumber, &number) == 2) {
 				currentPCX16Bank = (number >= 0xA000 && number <= 0xFFFF) ? bnumber & 0xFF : -1;
 			} else {
-				sscanf(line, "%x", &number);
-				if (!is_gen2) {
-					currentPCX16Bank = (number & 0xFFFF) >= 0xA000 ? (number >> 16) & 0xFF : -1;
-				} else if (number < 0xA000 || number >= 0x010000) {
-					currentPCX16Bank = -1;
+				if (sscanf(line, "%x", &number) == 1) {
+					if (!is_gen2) {
+						currentPCX16Bank = (number & 0xFFFF) >= 0xA000 ? (number >> 16) & 0xFF : -1;
+					} else if (number < 0xA000 || number >= 0x010000) {
+						currentPCX16Bank = -1;
+					}
+				} else {
+					break;
 				}
 			}
 			addr = number & (is_gen2 ? 0xFFFFFF : 0xFFFF);

--- a/src/debugger.c
+++ b/src/debugger.c
@@ -472,14 +472,12 @@ static void DEBUGExecCmd() {
 		case CMD_DUMP_MEM:
 			if (sscanf(line, "%x:%x", &bnumber, &number) == 2) {
 				currentX16Bank = bnumber & 0xFF;
-			} else {
-				if (sscanf(line, "%x", &number) == 1) {
-					if (!is_gen2) {
-						currentX16Bank = (number >> 16) & 0xFF;
-					}
-				} else {
-					break;
+			} else if (sscanf(line, "%x", &number) == 1) {
+				if (!is_gen2) {
+					currentX16Bank = (number >> 16) & 0xFF;
 				}
+			} else {
+				break;
 			}
 			addr = number & (is_gen2 ? 0xFFFFFF : 0xFFFF);
 			currentData = addr;
@@ -534,17 +532,16 @@ static void DEBUGExecCmd() {
 		case CMD_DISASM:
 			if (sscanf(line, "%x:%x", &bnumber, &number) == 2) {
 				currentPCX16Bank = (number >= 0xA000 && number <= 0xFFFF) ? bnumber & 0xFF : -1;
-			} else {
-				if (sscanf(line, "%x", &number) == 1) {
-					if (!is_gen2) {
-						currentPCX16Bank = (number & 0xFFFF) >= 0xA000 ? (number >> 16) & 0xFF : -1;
-					} else if (number < 0xA000 || number >= 0x010000) {
-						currentPCX16Bank = -1;
-					}
-				} else {
-					break;
+			} else if (sscanf(line, "%x", &number) == 1) {
+				if (!is_gen2) {
+					currentPCX16Bank = (number & 0xFFFF) >= 0xA000 ? (number >> 16) & 0xFF : -1;
+				} else if (number < 0xA000 || number >= 0x010000) {
+					currentPCX16Bank = -1;
 				}
+			} else {
+				break;
 			}
+
 			addr = number & (is_gen2 ? 0xFFFFFF : 0xFFFF);
 
 			currentPC = addr & 0xFFFF;
@@ -906,13 +903,14 @@ static int DEBUGRenderRegisters(void) {
 	}
 
 	if (breakPoint.pc < 0) {
-		DEBUGString(dbgRenderer, DBG_DATX, yc++, "----", col_data);
+		DEBUGString(dbgRenderer, DBG_DATX, yc++, "--:----", col_data);
 	} else if (breakPoint.x16Bank < 0) {
 		if (is_gen2) {
 			DEBUGNumber(DBG_DATX, yc, breakPoint.bank, 2, col_data);
 			DEBUGNumber(DBG_DATX+3, yc++, breakPoint.pc, 4, col_data);
 		} else {
-			DEBUGNumber(DBG_DATX, yc++, (uint16_t)breakPoint.pc, 4, col_data);
+			DEBUGString(dbgRenderer, DBG_DATX, yc, "--:", col_data);
+			DEBUGNumber(DBG_DATX+3, yc++, (uint16_t)breakPoint.pc, 4, col_data);
 		}
 	} else {
 		DEBUGNumber(DBG_DATX, yc, breakPoint.x16Bank, 2, col_data);


### PR DESCRIPTION
* In the debugger, changing the disassembly address with the `d` command, as well as with navigation (shift+cursor and shift+pgup/pgdn) should now update the debugger "current" X16 bank as appropriate, so that F9 set-breakpoint will get the correct values.

* The disassembly itself should now display the x16 bank properly if it flows from 9Fxx into A000.

* The breakpoint address display should now handle showing far addressing as 24 bit hex, e.g. "123456", as well as now displaying X16 banked addresses as "12:A000".

* When not in -gs mode, the low RAM breakpoint will show as 4-digit hex as it previously had.  In -gs mode, all breakpoint addresses are shown as 6 hex digits, save for X16 banked addresses between 0xA000 and 0xFFFF, which show as "xx:xxxx" 