### PR TITLE
HostFS: reject rename if target file exists, matching DOS behavior

### DIFF
--- a/src/ieee.c
+++ b/src/ieee.c
@@ -1387,7 +1387,7 @@ crename(uint8_t *f)
 	}
 
 	*(s++) = 0; // null-terminate d and advance s
-	
+
 	uint8_t *src;
 	uint8_t *dst;
 
@@ -1409,7 +1409,10 @@ crename(uint8_t *f)
 
 	free(tmp); // we're now done with d and s (part of tmp)
 
-	if (rename((char *)src, (char *)dst)) {
+	struct stat st;
+	if (stat((char *)dst, &st) == 0) { // if dst file exists, fail rename
+		set_error(0x63, 0, 0);
+	} else if (rename((char *)src, (char *)dst)) {
 		if (errno == EACCES) {
 			set_error(0x63, 0, 0);
 		} else if (errno == EINVAL) {


### PR DESCRIPTION
From a question on Discord

> How would you go about checking if a certain file exists on a drive? For the C64, I read the recommendation to issue a "R:<my_file>=<my_file>" command and check if the result code is 63 ("File exists"). I can confirm that this works both in VICE and on the real thing. However, when I try this (in assembler) on the X16 emulator using the host file system as "drive", I get an error code of 00, suggesting that there was no naming conflict with an existing file. Is this discrepancy between the two systems intentional? Am I missing something?