### PR TITLE
make layer y position follow hardware vstop behavior better

### DIFF
--- a/src/video.c
+++ b/src/video.c
@@ -1027,6 +1027,7 @@ render_line(uint16_t y, float scan_pos_x)
 
 	uint8_t dc_video = reg_composer[0];
 	uint16_t vstart = reg_composer[6] << 1;
+	uint16_t vstop = reg_composer[7] << 1;
 
 	if (y != y_prev) {
 		y_prev = y;
@@ -1051,13 +1052,13 @@ render_line(uint16_t y, float scan_pos_x)
 		if ((dc_video & 3) > 1) { // 480i or 240p
 			if ((y >> 1) == 0) {
 				eff_y_fp = y*(prev_reg_composer[1][2] << 9);
-			} else if ((y & 0xfffe) > vstart) {
+			} else if ( ((y & 0xfffe) >= vstart) && ((y & 0xfffe) < vstop) ) {
 				eff_y_fp += (prev_reg_composer[1][2] << 10);
 			}
 		} else {
 			if (y == 0) {
 				eff_y_fp = 0;
-			} else if (y > vstart) {
+			} else if ( (y >= vstart) && (y < vstop) ) {
 				eff_y_fp += (prev_reg_composer[1][2] << 9);
 			}
 		}
@@ -1090,7 +1091,6 @@ render_line(uint16_t y, float scan_pos_x)
 	uint8_t border_color = reg_composer[3];
 	uint16_t hstart = reg_composer[4] << 2;
 	uint16_t hstop = reg_composer[5] << 2;
-	uint16_t vstop = reg_composer[7] << 1;
 
 	uint16_t eff_y = (eff_y_fp >> 16);
 	if (eff_y >= 480) eff_y = 480 - (y & 1);


### PR DESCRIPTION
The emulator doesn't correctly set the layer y position with relating to  VSTOP changes done in line irqs halfway through the screen. Found when the following test program didn't work correctly on emulator but worked fine on hardware:

[split.zip](https://github.com/user-attachments/files/24403621/split.zip)

The goal of this program is to "split open" the screen from the middle and scroll  the upper part upwards and the lower part downwards. In the emulator, the layer y scroll of the lower part is not updated correctly and the effect is shown wrong (the text is not "pushed down"). 

*note:* morphinejh also found another difference in the relevant code in the emulator when compared to the Vera FPGA code where the check against VSTART seemed to be 1 off.  (>= vs >) this has been changed as well.  

Solution from this PR as discussed on discord:  https://discord.com/channels/547559626024157184/1029612422807433269/1455760243442188373

*note2:* Box16 also exhibits incorrect behavior here, It is unclear to me how this solution must be ported to it because the rendering code seems to be different than in the official emulator...