### PR TITLE
Improve the debugger's ability to write to the machine

### DIFF
--- a/src/debugger.c
+++ b/src/debugger.c
@@ -506,13 +506,9 @@ static void DEBUGExecCmd() {
 				if (dumpmode == DDUMP_RAM) {
 					addr &= 0xFFFFFF;
 					do {
-						if (addr >= 0xC000 && addr < 0x10000) {
-							// Nop.
-						} else if (addr >= 0xA000 && addr < 0xC000) {
-							BRAM[(currentX16Bank << 13) + addr - 0xA000] = number;
-						} else if ((addr >> 16) < num_banks) {
-							RAM[addr] = number;
-						}
+						uint8_t gen2Bank = addr >> 16;
+						uint16_t addr16 = addr & 0xFFFF;
+						debug_write6502(addr16, gen2Bank, number, currentX16Bank);
 						if (incr) {
 							addr += incr;
 						} else {

--- a/src/memory.h
+++ b/src/memory.h
@@ -14,6 +14,7 @@
 
 #define USE_CURRENT_X16_BANK (-1)
 #define debug_read6502(a, b, x) real_read6502((a), (b), true, (x))
+#define debug_write6502(a, b, v, x) real_write6502((a), (b), (v), true, (x))
 
 // X16 r0-r15
 #define X16_REG_R0L (direct_page_add(2))
@@ -52,6 +53,7 @@
 uint8_t read6502(uint16_t address, uint8_t bank);
 uint8_t real_read6502(uint16_t address, uint8_t bank, bool debugOn, int16_t x16Bank);
 void write6502(uint16_t address, uint8_t bank, uint8_t value);
+void real_write6502(uint16_t address, uint8_t bank, uint8_t value, bool debugOn, uint8_t x16Bank);
 void vp6502();
 
 void memory_init();


### PR DESCRIPTION
The debugger supports writing to the machine using the "FILL_MEMORY" command:

`f addr value [repeats] [increment rate]`

(It uses the x16 bank specified using `m bank:address`)

The existing implementation did only support writing to RAM.

This modification allows the debugger to also write to IO peripherals and cartridge memory, as well as modify ROM.

IO modification can be tested by activating the mouse cursor ("MOUSE 1"), then deactivate/activate the sprite enable bit in DC_VIDEO. The new state is immediately visible in the debugger, and, when running the system again, the next frames will be according to the new register state.

ROM modification can be tested by e.g writing "A" (41) to the bytes at 00:C000. The modification is immediately visible in the debugger. When typing "HELP" afterwards, the manipulated git sha is visible.