### PR TITLE
Don't use Lx_HSCROLL_H as a palette offset in 1bpp bitmap mode

### DIFF
--- a/src/video.c
+++ b/src/video.c
@@ -974,7 +974,8 @@ render_layer_line_bitmap(uint8_t layer, uint16_t y)
 		int xx = x % props->tilew;
 
 		// extract all information from the map
-		uint8_t palette_offset = reg_layer[layer][4] & 0xf;
+		// palette offset is ignored in 1bpp bitmap mode
+		uint8_t palette_offset = props->bits_per_pixel > 1 ? reg_layer[layer][4] & 0xf : 0;
 
 		// additional bytes to reach the correct column of the tile
 		uint16_t x_add = (xx * props->bits_per_pixel) >> 3;

--- a/src/video.c
+++ b/src/video.c
@@ -974,8 +974,7 @@ render_layer_line_bitmap(uint8_t layer, uint16_t y)
 		int xx = x % props->tilew;
 
 		// extract all information from the map
-		// palette offset is ignored in 1bpp bitmap mode
-		uint8_t palette_offset = props->bits_per_pixel > 1 ? reg_layer[layer][4] & 0xf : 0;
+		uint8_t palette_offset = reg_layer[layer][4] & 0xf;
 
 		// additional bytes to reach the correct column of the tile
 		uint16_t x_add = (xx * props->bits_per_pixel) >> 3;
@@ -985,8 +984,8 @@ render_layer_line_bitmap(uint8_t layer, uint16_t y)
 		// convert tile byte to indexed color
 		uint8_t col_index = (s >> (props->first_color_pos - ((xx & props->color_fields_max) << props->color_depth))) & props->color_mask;
 
-		// Apply Palette Offset
-		if (col_index > 0 && col_index < 16) {
+		// Apply Palette Offset, except in 1bpp mode
+		if (props->bits_per_pixel > 1 && col_index > 0 && col_index < 16) {
 			col_index += palette_offset << 4;
 			if (props->text_mode_256c) {
 				col_index |= 0x80;


### PR DESCRIPTION
This matches the behavior of the VERA hardware.