### PR TITLE
make sure that release build is the default again

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ BUILD_DIR = build
 all:
 	@cmake -E echo "Building with CMake"
 	cmake -E make_directory $(BUILD_DIR)
-	cmake -S . -B $(BUILD_DIR)
+	cmake -S . -B $(BUILD_DIR) -DCMAKE_BUILD_TYPE=Release
 	cmake --build $(BUILD_DIR) $(ARGS)
 
 	@cmake -E echo "x16emu and makecart executables can be found in ./$(BUILD_DIR)"


### PR DESCRIPTION
so -O3 compiler optimizations are enabled again. Otherwise a non optimizing default/debug build is being made.

Without this, it is reported that the emulator is unusable on some systems (such as RPi 400)

Also it fixes the performance of  the normal x86 desktop build. On my system it used to warp at 800-900% but has now been stuck at 250-300% since the switch to cmake.



**note** the ci builds fail not because of this particular PR but because there is a problem in the github action related to the pdf docs, this is fixed in #389