### PR TITLE
add local make wasm target again

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -290,7 +290,7 @@ if(EMSCRIPTEN)
     set_target_properties(x16emu PROPERTIES SUFFIX ".html")
     target_link_options(x16emu PRIVATE
         --shell-file ${CMAKE_CURRENT_SOURCE_DIR}/webassembly/x16emu-template.html
-        --preload-file ${CMAKE_CURRENT_SOURCE_DIR}/build/rom.bin
+        --preload-file ${CMAKE_CURRENT_BINARY_DIR}/rom.bin
         "SHELL:-s TOTAL_MEMORY=32MB"
         "SHELL:-s ASSERTIONS=1"
         "SHELL:-s DISABLE_DEPRECATED_FIND_EVENT_TARGET_BEHAVIOR=1"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -290,7 +290,7 @@ if(EMSCRIPTEN)
     set_target_properties(x16emu PROPERTIES SUFFIX ".html")
     target_link_options(x16emu PRIVATE
         --shell-file ${CMAKE_CURRENT_SOURCE_DIR}/webassembly/x16emu-template.html
-        --preload-file ${CMAKE_CURRENT_BINARY_DIR}/rom.bin
+        --preload-file ${CMAKE_CURRENT_BINARY_DIR}/rom.bin@rom.bin
         "SHELL:-s TOTAL_MEMORY=32MB"
         "SHELL:-s ASSERTIONS=1"
         "SHELL:-s DISABLE_DEPRECATED_FIND_EVENT_TARGET_BEHAVIOR=1"

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ BUILD_DIR = build
 all:
 	@cmake -E echo "Building with CMake"
 	cmake -E make_directory $(BUILD_DIR)
-	cmake -S . -B $(BUILD_DIR)
+	cmake -S . -B $(BUILD_DIR) -DCMAKE_BUILD_TYPE=Release
 	cmake --build $(BUILD_DIR) $(ARGS)
 
 	@cmake -E echo "x16emu and makecart executables can be found in ./$(BUILD_DIR)"

--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,9 @@
 ##################################################################################################
 
 BUILD_DIR = build
+WASM_BUILD_DIR = build-wasm
 
-.PHONY: all clean distclean
+.PHONY: all clean distclean wasm wasm-clean
 
 all:
 	@cmake -E echo "Building with CMake"
@@ -20,3 +21,28 @@ clean:
 
 distclean:
 	cmake -E remove_directory $(BUILD_DIR)
+
+# CMake needs this toolchain file to know it's cross-compiling for Emscripten.
+# Without it, it would use the host compiler instead of emcc.
+# The CI workflow uses emcmake (which passes this file automatically), but
+# emcmake is not always available locally, so we locate the file ourselves.
+EMSCRIPTEN_TOOLCHAIN ?= $(shell \
+	emcc=$$(command -v emcc 2>/dev/null) && \
+	dir=$$(dirname $$(readlink -f "$$emcc")) && \
+	echo "$$dir/cmake/Modules/Platform/Emscripten.cmake")
+
+wasm:
+	@cmake -E echo "Building WASM target with Emscripten"
+	cmake -E make_directory $(WASM_BUILD_DIR)
+	cp -n rom.bin $(WASM_BUILD_DIR)/ 2>/dev/null || true
+	cp -n build/rom.bin $(WASM_BUILD_DIR)/ 2>/dev/null || true
+	cmake -S . -B $(WASM_BUILD_DIR) -DCMAKE_TOOLCHAIN_FILE=$(EMSCRIPTEN_TOOLCHAIN) -DENABLE_FLUIDSYNTH=OFF -DENABLE_TRACE=OFF
+	cmake --build $(WASM_BUILD_DIR) $(ARGS)
+	@cmake -E echo "Packaging WASM artifacts into $(WASM_BUILD_DIR)/emu_binaries"
+	cmake -E make_directory $(WASM_BUILD_DIR)/emu_binaries/webassembly
+	cp $(WASM_BUILD_DIR)/x16emu.data $(WASM_BUILD_DIR)/x16emu.html $(WASM_BUILD_DIR)/x16emu.js $(WASM_BUILD_DIR)/x16emu.wasm $(WASM_BUILD_DIR)/emu_binaries/
+	cp webassembly/styles.css webassembly/main.js webassembly/jszip.min.js $(WASM_BUILD_DIR)/emu_binaries/webassembly/
+	@cmake -E echo "WASM artifacts can be found in ./$(WASM_BUILD_DIR)/emu_binaries"
+
+wasm-clean:
+	-cmake --build $(WASM_BUILD_DIR) --target clean 2>/dev/null

--- a/Makefile
+++ b/Makefile
@@ -16,11 +16,11 @@ all:
 	cmake --build $(BUILD_DIR) $(ARGS)
 
 	@cmake -E echo "x16emu and makecart executables can be found in ./$(BUILD_DIR)"
-clean:
-	-cmake --build $(BUILD_DIR) --target clean
+clean: wasm-clean
+	-cmake --build $(BUILD_DIR) --target clean 2>/dev/null
 
 distclean:
-	cmake -E remove_directory $(BUILD_DIR)
+	cmake -E remove_directory $(BUILD_DIR) $(WASM_BUILD_DIR)
 
 # CMake needs this toolchain file to know it's cross-compiling for Emscripten.
 # Without it, it would use the host compiler instead of emcc.
@@ -32,10 +32,31 @@ EMSCRIPTEN_TOOLCHAIN ?= $(shell \
 	echo "$$dir/cmake/Modules/Platform/Emscripten.cmake")
 
 wasm:
+	@if [ -z "$(EMSCRIPTEN_TOOLCHAIN)" ] || [ ! -f "$(EMSCRIPTEN_TOOLCHAIN)" ]; then \
+		echo "Error: EMSCRIPTEN_TOOLCHAIN not found or invalid."; \
+		echo "Please ensure Emscripten is installed and in your PATH."; \
+		exit 1; \
+	fi
 	@cmake -E echo "Building WASM target with Emscripten"
 	cmake -E make_directory $(WASM_BUILD_DIR)
 	cp -n rom.bin $(WASM_BUILD_DIR)/ 2>/dev/null || true
 	cp -n build/rom.bin $(WASM_BUILD_DIR)/ 2>/dev/null || true
+	@if [ ! -f $(WASM_BUILD_DIR)/rom.bin ]; then \
+		if [ -n "$(ROM_PATH)" ]; then \
+			if [ -f "$(ROM_PATH)" ]; then \
+				cp "$(ROM_PATH)" $(WASM_BUILD_DIR)/rom.bin; \
+			elif [ -d "$(ROM_PATH)" ] && [ -f "$(ROM_PATH)/rom.bin" ]; then \
+				cp "$(ROM_PATH)/rom.bin" $(WASM_BUILD_DIR)/rom.bin; \
+			else \
+				echo "Error: rom.bin not found at $(ROM_PATH)."; \
+				exit 1; \
+			fi; \
+		else \
+			echo "Error: rom.bin not found in $(WASM_BUILD_DIR)/."; \
+			echo "Please place rom.bin in $(WASM_BUILD_DIR)/ or set ROM_PATH environment variable to the location of your rom.bin."; \
+			exit 1; \
+		fi; \
+	fi
 	cmake -S . -B $(WASM_BUILD_DIR) -DCMAKE_TOOLCHAIN_FILE=$(EMSCRIPTEN_TOOLCHAIN) -DENABLE_FLUIDSYNTH=OFF -DENABLE_TRACE=OFF
 	cmake --build $(WASM_BUILD_DIR) $(ARGS)
 	@cmake -E echo "Packaging WASM artifacts into $(WASM_BUILD_DIR)/emu_binaries"


### PR DESCRIPTION
Adds a make wasm target again so you can build the wasm web emulator locally again. 
Requires emscripten to be installed as usual.

Fixes #375

disclaimer: most of the change was created by an AI agent because I don't know cmake very well.

**note** the ci builds fail not because of this particular PR but because there is a problem in the github action related to the pdf docs, this is fixed in #389