### PR TITLE
ci: skip x16-docs PDF fetch on fork PRs so the CI build action no longer fails on that

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -108,6 +108,7 @@ jobs:
           name: readme-pdf
           path: emu_binaries
       - name: Fetch x16-docs PDFs
+        if: github.event.pull_request.head.repo.fork == false
         run: gh run download -R X16Community/x16-docs -n x16-docs-pdf --dir emu_binaries
         shell: cmd
         env:
@@ -197,6 +198,7 @@ jobs:
           name: readme-pdf
           path: emu_binaries
       - name: Fetch x16-docs PDFs
+        if: github.event.pull_request.head.repo.fork == false
         run: gh run download -R X16Community/x16-docs -n x16-docs-pdf --dir emu_binaries
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -257,6 +259,7 @@ jobs:
           name: readme-pdf
           path: emu_binaries
       - name: Fetch x16-docs PDFs
+        if: github.event.pull_request.head.repo.fork == false
         run: gh run download -R X16Community/x16-docs -n x16-docs-pdf --dir emu_binaries
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -322,6 +325,7 @@ jobs:
           name: readme-pdf
           path: emu_binaries
       - name: Fetch x16-docs PDFs
+        if: github.event.pull_request.head.repo.fork == false
         run: gh run download -R X16Community/x16-docs -n x16-docs-pdf --dir emu_binaries
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -387,6 +391,7 @@ jobs:
           name: readme-pdf
           path: emu_binaries
       - name: Fetch x16-docs PDFs
+        if: github.event.pull_request.head.repo.fork == false
         run: gh run download -R X16Community/x16-docs -n x16-docs-pdf --dir emu_binaries
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -443,6 +448,7 @@ jobs:
           name: readme-pdf
           path: emu_binaries
       - name: Fetch x16-docs PDFs
+        if: github.event.pull_request.head.repo.fork == false
         run: gh run download -R X16Community/x16-docs -n x16-docs-pdf --dir emu_binaries
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -498,6 +504,7 @@ jobs:
           name: readme-pdf
           path: emu_binaries
       - name: Fetch x16-docs PDFs
+        if: github.event.pull_request.head.repo.fork == false
         run: gh run download -R X16Community/x16-docs -n x16-docs-pdf --dir emu_binaries
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The "Fetch x16-docs PDFs" step uses gh run download to pull artifacts from the X16Community/x16-docs repo. On pull requests from forks, the default GITHUB_TOKEN has restricted read-only permissions and cannot access other repositories, causing the build to fail. Add a condition to skip this step when the PR originates from a fork.
You can see below 2 of my PR's that now fail their CI build checks because of this issue.


There is likely anotherr problem as well  though, if the pdf artifact has been removed altogether from the x16-docs repo because it got stale/too old and github deemed it necessary to clean it....which seems to have happened as well.  I don't know how to solve this? Re-trigger a x16-docs build to make a fresh build artifact for a while until it expires again?  IS there a way to make github store the build artifacts longer?  
<img width="333" height="71" alt="image" src="https://github.com/user-attachments/assets/11cf079e-7dc0-49cf-b6db-01f4c41be1aa" />
