### PR TITLE
Added install rules to CMakeLists.txt file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -356,3 +356,6 @@ message(STATUS "================================================================
 message(STATUS "   Fluidsynth Support : ${FLUID_EN_MSG}")
 message(STATUS "   Trace Support      : ${TRACE_EN_MSG}")
 message(STATUS "=========================================================================\n")
+
+# Install rules for people who want to install this in a specific place on their system
+install(TARGETS x16emu makecart DESTINATION bin)


### PR DESCRIPTION
Hi,

I just added install rules to the CMakeLists.txt file so that people can install this on their system without having to worry about the clunk created from having to launch it from the build folder every time. I'm also working on a Flatpak version of this software, so even if this pull request doesn't get approved, I can still use my fork to build the Flatpak.